### PR TITLE
Alternativer DatePicker

### DIFF
--- a/Activities/MainActivity.cs
+++ b/Activities/MainActivity.cs
@@ -118,6 +118,7 @@ namespace VorratsUebersicht
             // Einstellungen für Warnhinweis beim OpenFoodFacts.org
             ArticleDetailsActivity.showCostMessage = Settings.GetBoolean("ShowOpenFoodFactsInternetCostsMessage", true);
 
+            StorageItemQuantityActivity.UseAltDatePicker = Settings.GetBoolean("UseAltDatePicker", false);
 
             if (MainActivity.IsGooglePlayPreLaunchTestMode)
             {

--- a/Activities/MainActivity.cs
+++ b/Activities/MainActivity.cs
@@ -22,6 +22,9 @@ namespace VorratsUebersicht
     [Activity(Label = " Vorratsübersicht", Icon = "@drawable/ic_launcher")]
     public class MainActivity : Activity
     {
+        // Debug-Konstanten
+        private static bool debug_date_picker = false;
+
         public static readonly int EditStorageItemQuantityId = 1001;
         public static readonly int OptionsId = 1002;
         public static readonly int ArticleListId = 1003;
@@ -119,6 +122,25 @@ namespace VorratsUebersicht
             ArticleDetailsActivity.showCostMessage = Settings.GetBoolean("ShowOpenFoodFactsInternetCostsMessage", true);
 
             StorageItemQuantityActivity.UseAltDatePicker = Settings.GetBoolean("UseAltDatePicker", false);
+
+            // DatePicker-DEBUG
+            if (debug_date_picker)
+            {
+                Android_Database.UseTestDatabase = true;
+                Button b = new Button(this.ApplicationContext);
+                b.Text = "Test DP";
+                b.Click += delegate
+                {
+                    AltDatePickerFragment frag = AltDatePickerFragment.NewInstance(delegate (DateTime? time) { b.Text = time!=null ? time.Value.ToShortDateString() : "Kein Datum"; }, DateTime.Today);
+                    frag.ShowsDialog = true;
+                    frag.Show(FragmentManager, AltDatePickerFragment.TAG);
+                };
+                FindViewById<LinearLayout>(Resource.Id.MainLinearLayout).AddView(b);
+                AltDatePickerFragment frag2 = AltDatePickerFragment.NewInstance(delegate (DateTime? time) { b.Text = time != null ? time.Value.ToShortDateString() : "Kein Datum"; }, DateTime.Today);
+                frag2.ShowsDialog = true;
+                frag2.Show(FragmentManager, AltDatePickerFragment.TAG);
+            }
+
 
             if (MainActivity.IsGooglePlayPreLaunchTestMode)
             {

--- a/Activities/SettingsActivity.cs
+++ b/Activities/SettingsActivity.cs
@@ -54,6 +54,10 @@ namespace VorratsUebersicht
             switchCostMessage.Click += SwitchCostMessage_Click;
             switchCostMessage.Checked = ArticleDetailsActivity.showCostMessage;
 
+            Switch switchAltDatePicker = FindViewById<Switch>(Resource.Id.SettingsButton_AltDatePicker);
+            switchAltDatePicker.Click += switchAltDatePicker_Click;
+            switchAltDatePicker.Checked = StorageItemQuantityActivity.UseAltDatePicker;
+
             Button buttonRestoreSampleDb = FindViewById<Button>(Resource.Id.SettingsButton_RestoreSampleDb);
             buttonRestoreSampleDb.Click += ButtonRestoreSampleDb_Click;
 
@@ -498,6 +502,13 @@ namespace VorratsUebersicht
             Settings.PutBoolean("ShowOpenFoodFactsInternetCostsMessage", ArticleDetailsActivity.showCostMessage);
         }
 
+        private void switchAltDatePicker_Click(object sender, EventArgs e)
+        {
+            var switchAltDatePicker = sender as Switch;
+            StorageItemQuantityActivity.UseAltDatePicker = switchAltDatePicker.Checked;
+            Settings.PutBoolean("UseAltDatePicker", StorageItemQuantityActivity.UseAltDatePicker);
+        }
+        
         private void ButtonRestore_Click(object sender, EventArgs e)
         {
             // Backups müssen sich im Download Verzeichnis befinden.

--- a/Activities/StorageItemQuantityActivity.cs
+++ b/Activities/StorageItemQuantityActivity.cs
@@ -25,6 +25,7 @@ namespace VorratsUebersicht
         public static List<StorageItemQuantityListView> liste = null;
         public static Article article = null;
         public static ArticleImage articleImage = null;
+        public static bool UseAltDatePicker;
 
         int articleId;
         string text;
@@ -133,17 +134,35 @@ namespace VorratsUebersicht
             if (!this.durableInfinity)
             {
                 // Haltbarkeitsdatum erfassen (kann aber auch weggelassen werden)
-				DatePickerFragment frag = DatePickerFragment.NewInstance(delegate(DateTime? time) 
-						{
+                listView.InvalidateViews();
+                if (!UseAltDatePicker)
+                {
+                    DatePickerFragment frag = DatePickerFragment.NewInstance(delegate (DateTime? time)
+                        {
                             if (time.HasValue)
-							    storageItemQuantity.BestBefore = time.Value;
+                                storageItemQuantity.BestBefore = time.Value;
                             else
-							    storageItemQuantity.BestBefore = null;
+                                storageItemQuantity.BestBefore = null;
 
                             listView.InvalidateViews();
-						}, DateTime.Today);
-				frag.ShowsDialog = true;
-				frag.Show(FragmentManager, DatePickerFragment.TAG);
+                        }, DateTime.Today);
+                    frag.ShowsDialog = true;
+                    frag.Show(FragmentManager, DatePickerFragment.TAG);
+                } else
+                {
+                    AltDatePickerFragment frag = AltDatePickerFragment.NewInstance(delegate (DateTime? time)
+                    {
+                        if (time.HasValue)
+                            storageItemQuantity.BestBefore = time.Value;
+                        else
+                            storageItemQuantity.BestBefore = null;
+
+                        listView.InvalidateViews();
+                    }, DateTime.Today);
+                    frag.ShowsDialog = true;
+                    frag.Show(FragmentManager, AltDatePickerFragment.TAG);
+
+                }
             }
             else
             {
@@ -507,18 +526,40 @@ namespace VorratsUebersicht
             DateTime? date = storageItem.BestBefore;
 
             // Haltbarkeitsdatum erfassen (kann aber auch weggelassen werden)
-			DatePickerFragment frag = DatePickerFragment.NewInstance(delegate(DateTime? time) 
-					{
-                        if (time.HasValue)
-							storageItem.BestBefore = time.Value;
-                        else
-							storageItem.BestBefore = null;
+            storageItem.IsChanged = true;
+            adapter.NotifyDataSetInvalidated();
 
-                        storageItem.IsChanged = true;
-                        adapter.NotifyDataSetInvalidated();
-					}, date);
-			frag.ShowsDialog = true;
-			frag.Show(FragmentManager, DatePickerFragment.TAG);
+
+            if (!UseAltDatePicker)
+            {
+                DatePickerFragment frag = DatePickerFragment.NewInstance(delegate (DateTime? time)
+                {
+                    if (time.HasValue)
+                        storageItem.BestBefore = time.Value;
+                    else
+                        storageItem.BestBefore = null;
+
+                    storageItem.IsChanged = true;
+                    adapter.NotifyDataSetInvalidated();
+                }, date);
+                frag.ShowsDialog = true;
+                frag.Show(FragmentManager, DatePickerFragment.TAG);
+            }
+            else
+            {
+                AltDatePickerFragment frag = AltDatePickerFragment.NewInstance(delegate (DateTime? time)
+                {
+                    if (time.HasValue)
+                        storageItem.BestBefore = time.Value;
+                    else
+                        storageItem.BestBefore = null;
+
+                    storageItem.IsChanged = true;
+                    adapter.NotifyDataSetInvalidated();
+                }, date);
+                frag.ShowsDialog = true;
+                frag.Show(FragmentManager, AltDatePickerFragment.TAG);
+            }
         }
 
         private void ChangeQuantity(StorageItemQuantityResult storageItem, StorageItemQuantityListViewAdapter adapter)

--- a/Resources/Resource.Designer.cs
+++ b/Resources/Resource.Designer.cs
@@ -209,512 +209,506 @@ namespace VorratsUebersicht
 		public partial class Id
 		{
 			
+			// aapt resource value: 0x7f0a0089
+			public const int ArticleDetailsMenu_Cancel = 2131361929;
+			
 			// aapt resource value: 0x7f0a008b
-			public const int ArticleDetailsMenu_Cancel = 2131361931;
-			
-			// aapt resource value: 0x7f0a008d
-			public const int ArticleDetailsMenu_Delete = 2131361933;
-			
-			// aapt resource value: 0x7f0a0095
-			public const int ArticleDetailsMenu_InternetDB = 2131361941;
-			
-			// aapt resource value: 0x7f0a008e
-			public const int ArticleDetailsMenu_MakeAPhoto = 2131361934;
-			
-			// aapt resource value: 0x7f0a008c
-			public const int ArticleDetailsMenu_Save = 2131361932;
-			
-			// aapt resource value: 0x7f0a0091
-			public const int ArticleDetailsMenu_ScanEAN = 2131361937;
-			
-			// aapt resource value: 0x7f0a008f
-			public const int ArticleDetailsMenu_SelectAPicture = 2131361935;
-			
-			// aapt resource value: 0x7f0a0090
-			public const int ArticleDetailsMenu_ShowPicture = 2131361936;
-			
-			// aapt resource value: 0x7f0a0094
-			public const int ArticleDetailsMenu_Speech = 2131361940;
-			
-			// aapt resource value: 0x7f0a0092
-			public const int ArticleDetailsMenu_ToShoppingList = 2131361938;
+			public const int ArticleDetailsMenu_Delete = 2131361931;
 			
 			// aapt resource value: 0x7f0a0093
-			public const int ArticleDetailsMenu_ToStorageQuantity = 2131361939;
+			public const int ArticleDetailsMenu_InternetDB = 2131361939;
 			
-			// aapt resource value: 0x7f0a0022
-			public const int ArticleDetails_ArticleId = 2131361826;
-			
-			// aapt resource value: 0x7f0a001d
-			public const int ArticleDetails_Calorie = 2131361821;
-			
-			// aapt resource value: 0x7f0a001b
-			public const int ArticleDetails_CaloriePerUnit = 2131361819;
-			
-			// aapt resource value: 0x7f0a001a
-			public const int ArticleDetails_CaloriePerUnitLabel = 2131361818;
-			
-			// aapt resource value: 0x7f0a0019
-			public const int ArticleDetails_CaloriesPerUnitSection = 2131361817;
-			
-			// aapt resource value: 0x7f0a001c
-			public const int ArticleDetails_CaloriesSection = 2131361820;
-			
-			// aapt resource value: 0x7f0a000c
-			public const int ArticleDetails_Category = 2131361804;
-			
-			// aapt resource value: 0x7f0a0013
-			public const int ArticleDetails_DurableInfinity = 2131361811;
-			
-			// aapt resource value: 0x7f0a0020
-			public const int ArticleDetails_EANCode = 2131361824;
-			
-			// aapt resource value: 0x7f0a0005
-			public const int ArticleDetails_Image = 2131361797;
-			
-			// aapt resource value: 0x7f0a0006
-			public const int ArticleDetails_Image2 = 2131361798;
-			
-			// aapt resource value: 0x7f0a0007
-			public const int ArticleDetails_ImageText = 2131361799;
-			
-			// aapt resource value: 0x7f0a000a
-			public const int ArticleDetails_Manufacturer = 2131361802;
-			
-			// aapt resource value: 0x7f0a001e
-			public const int ArticleDetails_MinQuantity = 2131361822;
-			
-			// aapt resource value: 0x7f0a0009
-			public const int ArticleDetails_Name = 2131361801;
-			
-			// aapt resource value: 0x7f0a0021
-			public const int ArticleDetails_Notes = 2131361825;
-			
-			// aapt resource value: 0x7f0a001f
-			public const int ArticleDetails_PrefQuantity = 2131361823;
-			
-			// aapt resource value: 0x7f0a0016
-			public const int ArticleDetails_Price = 2131361814;
-			
-			// aapt resource value: 0x7f0a000b
-			public const int ArticleDetails_SelectManufacturer = 2131361803;
-			
-			// aapt resource value: 0x7f0a0012
-			public const int ArticleDetails_SelectStorage = 2131361810;
-			
-			// aapt resource value: 0x7f0a000e
-			public const int ArticleDetails_SelectSubCategory = 2131361806;
-			
-			// aapt resource value: 0x7f0a0010
-			public const int ArticleDetails_SelectSupermarket = 2131361808;
-			
-			// aapt resource value: 0x7f0a0017
-			public const int ArticleDetails_Size = 2131361815;
-			
-			// aapt resource value: 0x7f0a0011
-			public const int ArticleDetails_Storage = 2131361809;
-			
-			// aapt resource value: 0x7f0a000d
-			public const int ArticleDetails_SubCategory = 2131361805;
-			
-			// aapt resource value: 0x7f0a000f
-			public const int ArticleDetails_Supermarket = 2131361807;
-			
-			// aapt resource value: 0x7f0a0018
-			public const int ArticleDetails_Unit = 2131361816;
-			
-			// aapt resource value: 0x7f0a0015
-			public const int ArticleDetails_WarnInDays = 2131361813;
-			
-			// aapt resource value: 0x7f0a0014
-			public const int ArticleDetails_WarnInDaysLabel = 2131361812;
-			
-			// aapt resource value: 0x7f0a0096
-			public const int ArticleImageMenu_RotateRight = 2131361942;
-			
-			// aapt resource value: 0x7f0a0025
-			public const int ArticleImage_Image = 2131361829;
-			
-			// aapt resource value: 0x7f0a0024
-			public const int ArticleImage_Info = 2131361828;
-			
-			// aapt resource value: 0x7f0a0023
-			public const int ArticleImage_ProgressBar = 2131361827;
-			
-			// aapt resource value: 0x7f0a002a
-			public const int ArticleList = 2131361834;
-			
-			// aapt resource value: 0x7f0a002d
-			public const int ArticleListView_Heading = 2131361837;
-			
-			// aapt resource value: 0x7f0a002b
-			public const int ArticleListView_Image = 2131361835;
-			
-			// aapt resource value: 0x7f0a002f
-			public const int ArticleListView_IsInStorage = 2131361839;
-			
-			// aapt resource value: 0x7f0a0033
-			public const int ArticleListView_Notes = 2131361843;
-			
-			// aapt resource value: 0x7f0a0031
-			public const int ArticleListView_OnShoppingList = 2131361841;
-			
-			// aapt resource value: 0x7f0a0032
-			public const int ArticleListView_ShoppingQuantity = 2131361842;
-			
-			// aapt resource value: 0x7f0a0030
-			public const int ArticleListView_StorageQuantity = 2131361840;
-			
-			// aapt resource value: 0x7f0a002e
-			public const int ArticleListView_SubHeading = 2131361838;
-			
-			// aapt resource value: 0x7f0a002c
-			public const int ArticleListView_Text = 2131361836;
-			
-			// aapt resource value: 0x7f0a0098
-			public const int ArticleList_Add = 2131361944;
-			
-			// aapt resource value: 0x7f0a0028
-			public const int ArticleList_Categories = 2131361832;
-			
-			// aapt resource value: 0x7f0a0027
-			public const int ArticleList_Category = 2131361831;
-			
-			// aapt resource value: 0x7f0a0029
-			public const int ArticleList_Footer = 2131361833;
-			
-			// aapt resource value: 0x7f0a0097
-			public const int ArticleList_Search = 2131361943;
-			
-			// aapt resource value: 0x7f0a0026
-			public const int ArticleList_SelectCategory = 2131361830;
-			
-			// aapt resource value: 0x7f0a0099
-			public const int ArticleList_Share = 2131361945;
-			
-			// aapt resource value: 0x7f0a0034
-			public const int InternetDatabaseResult = 2131361844;
-			
-			// aapt resource value: 0x7f0a0039
-			public const int InternetDatabaseResult_Description = 2131361849;
-			
-			// aapt resource value: 0x7f0a0037
-			public const int InternetDatabaseResult_Image = 2131361847;
-			
-			// aapt resource value: 0x7f0a0035
-			public const int InternetDatabaseResult_Progress = 2131361845;
-			
-			// aapt resource value: 0x7f0a0036
-			public const int InternetDatabaseResult_ProgressText = 2131361846;
-			
-			// aapt resource value: 0x7f0a009a
-			public const int InternetDatabaseResult_Save = 2131361946;
-			
-			// aapt resource value: 0x7f0a0038
-			public const int InternetDatabaseResult_Text = 2131361848;
-			
-			// aapt resource value: 0x7f0a003a
-			public const int Licenses_Text = 2131361850;
-			
-			// aapt resource value: 0x7f0a0041
-			public const int MainButton_Artikeldaten = 2131361857;
-			
-			// aapt resource value: 0x7f0a0042
-			public const int MainButton_Barcode = 2131361858;
-			
-			// aapt resource value: 0x7f0a003f
-			public const int MainButton_Kategorie = 2131361855;
-			
-			// aapt resource value: 0x7f0a0040
-			public const int MainButton_Lagerbestand = 2131361856;
-			
-			// aapt resource value: 0x7f0a0043
-			public const int MainButton_ShoppingList = 2131361859;
-			
-			// aapt resource value: 0x7f0a009b
-			public const int Main_Menu_Options = 2131361947;
-			
-			// aapt resource value: 0x7f0a003b
-			public const int Main_Text = 2131361851;
-			
-			// aapt resource value: 0x7f0a003c
-			public const int Main_Text1 = 2131361852;
-			
-			// aapt resource value: 0x7f0a003d
-			public const int Main_Text2 = 2131361853;
-			
-			// aapt resource value: 0x7f0a003e
-			public const int Main_TextInfo = 2131361854;
-			
-			// aapt resource value: 0x7f0a0008
-			public const int ProgressBar = 2131361800;
-			
-			// aapt resource value: 0x7f0a004e
-			public const int ProgressBar_BackupAndRestore = 2131361870;
-			
-			// aapt resource value: 0x7f0a0049
-			public const int ProgressBar_Compress = 2131361865;
-			
-			// aapt resource value: 0x7f0a0052
-			public const int ProgressBar_RestoreSampleDb = 2131361874;
-			
-			// aapt resource value: 0x7f0a0047
-			public const int SelectFile = 2131361863;
-			
-			// aapt resource value: 0x7f0a0045
-			public const int SelectFile_Button = 2131361861;
-			
-			// aapt resource value: 0x7f0a0046
-			public const int SelectFile_Message = 2131361862;
-			
-			// aapt resource value: 0x7f0a0044
-			public const int SelectFile_Path = 2131361860;
-			
-			// aapt resource value: 0x7f0a0058
-			public const int SettingsButton_AdditionalDatabasePath = 2131361880;
-			
-			// aapt resource value: 0x7f0a0059
-			public const int SettingsButton_AltDatePicker = 2131361881;
-			
-			// aapt resource value: 0x7f0a004f
-			public const int SettingsButton_Backup = 2131361871;
-			
-			// aapt resource value: 0x7f0a004a
-			public const int SettingsButton_Compress = 2131361866;
-			
-			// aapt resource value: 0x7f0a005a
-			public const int SettingsButton_CopyAppDbToSdCard = 2131361882;
-			
-			// aapt resource value: 0x7f0a0055
-			public const int SettingsButton_CsvExportArticles = 2131361877;
-			
-			// aapt resource value: 0x7f0a0056
-			public const int SettingsButton_CsvExportStorageItems = 2131361878;
-			
-			// aapt resource value: 0x7f0a0048
-			public const int SettingsButton_DatabasePath = 2131361864;
-			
-			// aapt resource value: 0x7f0a005e
-			public const int SettingsButton_Kontakt = 2131361886;
-			
-			// aapt resource value: 0x7f0a005c
-			public const int SettingsButton_Licenses = 2131361884;
-			
-			// aapt resource value: 0x7f0a004b
-			public const int SettingsButton_Repair = 2131361867;
-			
-			// aapt resource value: 0x7f0a0050
-			public const int SettingsButton_Restore = 2131361872;
-			
-			// aapt resource value: 0x7f0a0054
-			public const int SettingsButton_RestoreDb0 = 2131361876;
-			
-			// aapt resource value: 0x7f0a0053
-			public const int SettingsButton_RestoreSampleDb = 2131361875;
-			
-			// aapt resource value: 0x7f0a005b
-			public const int SettingsButton_SendLogFile = 2131361883;
-			
-			// aapt resource value: 0x7f0a0057
-			public const int SettingsButton_ShowOFFCostMessage = 2131361879;
-			
-			// aapt resource value: 0x7f0a0051
-			public const int SettingsButton_SwitchToTestDB = 2131361873;
-			
-			// aapt resource value: 0x7f0a005d
-			public const int SettingsButton_Version = 2131361885;
-			
-			// aapt resource value: 0x7f0a004d
-			public const int Settings_Categories = 2131361869;
-			
-			// aapt resource value: 0x7f0a004c
-			public const int Settings_Categories_Text = 2131361868;
-			
-			// aapt resource value: 0x7f0a0062
-			public const int ShoppingItemList = 2131361890;
-			
-			// aapt resource value: 0x7f0a0068
-			public const int ShoppingItemListView_Bought = 2131361896;
-			
-			// aapt resource value: 0x7f0a0065
-			public const int ShoppingItemListView_Heading = 2131361893;
-			
-			// aapt resource value: 0x7f0a0063
-			public const int ShoppingItemListView_Image = 2131361891;
-			
-			// aapt resource value: 0x7f0a0067
-			public const int ShoppingItemListView_Quantity = 2131361895;
-			
-			// aapt resource value: 0x7f0a0066
-			public const int ShoppingItemListView_SubHeading = 2131361894;
-			
-			// aapt resource value: 0x7f0a0064
-			public const int ShoppingItemListView_Text = 2131361892;
-			
-			// aapt resource value: 0x7f0a0061
-			public const int ShoppingItemList_Footer = 2131361889;
-			
-			// aapt resource value: 0x7f0a005f
-			public const int ShoppingItemList_SelectSupermarket = 2131361887;
-			
-			// aapt resource value: 0x7f0a0060
-			public const int ShoppingItemList_Spinner = 2131361888;
-			
-			// aapt resource value: 0x7f0a009d
-			public const int ShoppingList_Add = 2131361949;
-			
-			// aapt resource value: 0x7f0a009c
-			public const int ShoppingList_Search = 2131361948;
-			
-			// aapt resource value: 0x7f0a009e
-			public const int ShoppingList_Share = 2131361950;
-			
-			// aapt resource value: 0x7f0a0071
-			public const int SimpleImageViewText = 2131361905;
-			
-			// aapt resource value: 0x7f0a006a
-			public const int SplashScreen_ProgressBar = 2131361898;
-			
-			// aapt resource value: 0x7f0a0069
-			public const int SplashScreen_ProgressText = 2131361897;
-			
-			// aapt resource value: 0x7f0a0070
-			public const int StorageItemListView_Image = 2131361904;
-			
-			// aapt resource value: 0x7f0a0077
-			public const int StorageItemListView_OnShoppingList = 2131361911;
-			
-			// aapt resource value: 0x7f0a0078
-			public const int StorageItemListView_ShoppingQuantity = 2131361912;
-			
-			// aapt resource value: 0x7f0a0073
-			public const int StorageItemListView_TextDetails = 2131361907;
-			
-			// aapt resource value: 0x7f0a0074
-			public const int StorageItemListView_TextError = 2131361908;
-			
-			// aapt resource value: 0x7f0a0072
-			public const int StorageItemListView_TextHeader = 2131361906;
-			
-			// aapt resource value: 0x7f0a0076
-			public const int StorageItemListView_TextInfo = 2131361910;
-			
-			// aapt resource value: 0x7f0a0075
-			public const int StorageItemListView_TextWarning = 2131361909;
-			
-			// aapt resource value: 0x7f0a00a1
-			public const int StorageItemList_Add = 2131361953;
-			
-			// aapt resource value: 0x7f0a006e
-			public const int StorageItemList_Footer = 2131361902;
-			
-			// aapt resource value: 0x7f0a009f
-			public const int StorageItemList_Search = 2131361951;
-			
-			// aapt resource value: 0x7f0a006b
-			public const int StorageItemList_SelectStorageSection = 2131361899;
-			
-			// aapt resource value: 0x7f0a00a2
-			public const int StorageItemList_Share = 2131361954;
-			
-			// aapt resource value: 0x7f0a00a0
-			public const int StorageItemList_Sort = 2131361952;
-			
-			// aapt resource value: 0x7f0a006d
-			public const int StorageItemList_Storages = 2131361901;
-			
-			// aapt resource value: 0x7f0a006c
-			public const int StorageItemList_TextStorage = 2131361900;
-			
-			// aapt resource value: 0x7f0a0084
-			public const int StorageItemQuantityListView = 2131361924;
-			
-			// aapt resource value: 0x7f0a0085
-			public const int StorageItemQuantityList_Add = 2131361925;
-			
-			// aapt resource value: 0x7f0a0087
-			public const int StorageItemQuantityList_Date = 2131361927;
-			
-			// aapt resource value: 0x7f0a0086
-			public const int StorageItemQuantityList_Quantity = 2131361926;
-			
-			// aapt resource value: 0x7f0a0089
-			public const int StorageItemQuantityList_Remove = 2131361929;
-			
-			// aapt resource value: 0x7f0a0088
-			public const int StorageItemQuantityList_Storage = 2131361928;
-			
-			// aapt resource value: 0x7f0a0083
-			public const int StorageItemQuantity_AddArticle = 2131361923;
-			
-			// aapt resource value: 0x7f0a007b
-			public const int StorageItemQuantity_ArticleDetail = 2131361915;
-			
-			// aapt resource value: 0x7f0a0079
-			public const int StorageItemQuantity_ArticleDetailHeader = 2131361913;
-			
-			// aapt resource value: 0x7f0a00a5
-			public const int StorageItemQuantity_Cancel = 2131361957;
-			
-			// aapt resource value: 0x7f0a00a3
-			public const int StorageItemQuantity_Edit = 2131361955;
-			
-			// aapt resource value: 0x7f0a00a4
-			public const int StorageItemQuantity_EditPicture = 2131361956;
-			
-			// aapt resource value: 0x7f0a007a
-			public const int StorageItemQuantity_Image = 2131361914;
-			
-			// aapt resource value: 0x7f0a00a6
-			public const int StorageItemQuantity_Save = 2131361958;
-			
-			// aapt resource value: 0x7f0a007f
-			public const int StorageItemQuantity_SelectStorage = 2131361919;
-			
-			// aapt resource value: 0x7f0a0080
-			public const int StorageItemQuantity_Step = 2131361920;
-			
-			// aapt resource value: 0x7f0a0081
-			public const int StorageItemQuantity_StepButton = 2131361921;
-			
-			// aapt resource value: 0x7f0a0082
-			public const int StorageItemQuantity_StepText = 2131361922;
-			
-			// aapt resource value: 0x7f0a007c
-			public const int StorageItemQuantity_Storage = 2131361916;
-			
-			// aapt resource value: 0x7f0a007d
-			public const int StorageItemQuantity_StorageLabel = 2131361917;
-			
-			// aapt resource value: 0x7f0a007e
-			public const int StorageItemQuantity_StorageText = 2131361918;
-			
-			// aapt resource value: 0x7f0a00a8
-			public const int StorageItemQuantity_ToArticleDetails = 2131361960;
-			
-			// aapt resource value: 0x7f0a00a7
-			public const int StorageItemQuantity_ToShoppingList = 2131361959;
-			
-			// aapt resource value: 0x7f0a006f
-			public const int StorageItemView = 2131361903;
-			
-			// aapt resource value: 0x7f0a0001
-			public const int button1 = 2131361793;
-			
-			// aapt resource value: 0x7f0a0003
-			public const int button2 = 2131361795;
+			// aapt resource value: 0x7f0a008c
+			public const int ArticleDetailsMenu_MakeAPhoto = 2131361932;
 			
 			// aapt resource value: 0x7f0a008a
-			public const int contentFrame = 2131361930;
+			public const int ArticleDetailsMenu_Save = 2131361930;
+			
+			// aapt resource value: 0x7f0a008f
+			public const int ArticleDetailsMenu_ScanEAN = 2131361935;
+			
+			// aapt resource value: 0x7f0a008d
+			public const int ArticleDetailsMenu_SelectAPicture = 2131361933;
+			
+			// aapt resource value: 0x7f0a008e
+			public const int ArticleDetailsMenu_ShowPicture = 2131361934;
+			
+			// aapt resource value: 0x7f0a0092
+			public const int ArticleDetailsMenu_Speech = 2131361938;
+			
+			// aapt resource value: 0x7f0a0090
+			public const int ArticleDetailsMenu_ToShoppingList = 2131361936;
+			
+			// aapt resource value: 0x7f0a0091
+			public const int ArticleDetailsMenu_ToStorageQuantity = 2131361937;
+			
+			// aapt resource value: 0x7f0a001f
+			public const int ArticleDetails_ArticleId = 2131361823;
+			
+			// aapt resource value: 0x7f0a001a
+			public const int ArticleDetails_Calorie = 2131361818;
+			
+			// aapt resource value: 0x7f0a0018
+			public const int ArticleDetails_CaloriePerUnit = 2131361816;
+			
+			// aapt resource value: 0x7f0a0017
+			public const int ArticleDetails_CaloriePerUnitLabel = 2131361815;
+			
+			// aapt resource value: 0x7f0a0016
+			public const int ArticleDetails_CaloriesPerUnitSection = 2131361814;
+			
+			// aapt resource value: 0x7f0a0019
+			public const int ArticleDetails_CaloriesSection = 2131361817;
+			
+			// aapt resource value: 0x7f0a0009
+			public const int ArticleDetails_Category = 2131361801;
+			
+			// aapt resource value: 0x7f0a0010
+			public const int ArticleDetails_DurableInfinity = 2131361808;
+			
+			// aapt resource value: 0x7f0a001d
+			public const int ArticleDetails_EANCode = 2131361821;
+			
+			// aapt resource value: 0x7f0a0002
+			public const int ArticleDetails_Image = 2131361794;
+			
+			// aapt resource value: 0x7f0a0003
+			public const int ArticleDetails_Image2 = 2131361795;
+			
+			// aapt resource value: 0x7f0a0004
+			public const int ArticleDetails_ImageText = 2131361796;
+			
+			// aapt resource value: 0x7f0a0007
+			public const int ArticleDetails_Manufacturer = 2131361799;
+			
+			// aapt resource value: 0x7f0a001b
+			public const int ArticleDetails_MinQuantity = 2131361819;
+			
+			// aapt resource value: 0x7f0a0006
+			public const int ArticleDetails_Name = 2131361798;
+			
+			// aapt resource value: 0x7f0a001e
+			public const int ArticleDetails_Notes = 2131361822;
+			
+			// aapt resource value: 0x7f0a001c
+			public const int ArticleDetails_PrefQuantity = 2131361820;
+			
+			// aapt resource value: 0x7f0a0013
+			public const int ArticleDetails_Price = 2131361811;
+			
+			// aapt resource value: 0x7f0a0008
+			public const int ArticleDetails_SelectManufacturer = 2131361800;
+			
+			// aapt resource value: 0x7f0a000f
+			public const int ArticleDetails_SelectStorage = 2131361807;
+			
+			// aapt resource value: 0x7f0a000b
+			public const int ArticleDetails_SelectSubCategory = 2131361803;
+			
+			// aapt resource value: 0x7f0a000d
+			public const int ArticleDetails_SelectSupermarket = 2131361805;
+			
+			// aapt resource value: 0x7f0a0014
+			public const int ArticleDetails_Size = 2131361812;
+			
+			// aapt resource value: 0x7f0a000e
+			public const int ArticleDetails_Storage = 2131361806;
+			
+			// aapt resource value: 0x7f0a000a
+			public const int ArticleDetails_SubCategory = 2131361802;
+			
+			// aapt resource value: 0x7f0a000c
+			public const int ArticleDetails_Supermarket = 2131361804;
+			
+			// aapt resource value: 0x7f0a0015
+			public const int ArticleDetails_Unit = 2131361813;
+			
+			// aapt resource value: 0x7f0a0012
+			public const int ArticleDetails_WarnInDays = 2131361810;
+			
+			// aapt resource value: 0x7f0a0011
+			public const int ArticleDetails_WarnInDaysLabel = 2131361809;
+			
+			// aapt resource value: 0x7f0a0094
+			public const int ArticleImageMenu_RotateRight = 2131361940;
+			
+			// aapt resource value: 0x7f0a0022
+			public const int ArticleImage_Image = 2131361826;
+			
+			// aapt resource value: 0x7f0a0021
+			public const int ArticleImage_Info = 2131361825;
+			
+			// aapt resource value: 0x7f0a0020
+			public const int ArticleImage_ProgressBar = 2131361824;
+			
+			// aapt resource value: 0x7f0a0027
+			public const int ArticleList = 2131361831;
+			
+			// aapt resource value: 0x7f0a002a
+			public const int ArticleListView_Heading = 2131361834;
+			
+			// aapt resource value: 0x7f0a0028
+			public const int ArticleListView_Image = 2131361832;
+			
+			// aapt resource value: 0x7f0a002c
+			public const int ArticleListView_IsInStorage = 2131361836;
+			
+			// aapt resource value: 0x7f0a0030
+			public const int ArticleListView_Notes = 2131361840;
+			
+			// aapt resource value: 0x7f0a002e
+			public const int ArticleListView_OnShoppingList = 2131361838;
+			
+			// aapt resource value: 0x7f0a002f
+			public const int ArticleListView_ShoppingQuantity = 2131361839;
+			
+			// aapt resource value: 0x7f0a002d
+			public const int ArticleListView_StorageQuantity = 2131361837;
+			
+			// aapt resource value: 0x7f0a002b
+			public const int ArticleListView_SubHeading = 2131361835;
+			
+			// aapt resource value: 0x7f0a0029
+			public const int ArticleListView_Text = 2131361833;
+			
+			// aapt resource value: 0x7f0a0096
+			public const int ArticleList_Add = 2131361942;
+			
+			// aapt resource value: 0x7f0a0025
+			public const int ArticleList_Categories = 2131361829;
+			
+			// aapt resource value: 0x7f0a0024
+			public const int ArticleList_Category = 2131361828;
+			
+			// aapt resource value: 0x7f0a0026
+			public const int ArticleList_Footer = 2131361830;
+			
+			// aapt resource value: 0x7f0a0095
+			public const int ArticleList_Search = 2131361941;
+			
+			// aapt resource value: 0x7f0a0023
+			public const int ArticleList_SelectCategory = 2131361827;
+			
+			// aapt resource value: 0x7f0a0097
+			public const int ArticleList_Share = 2131361943;
+			
+			// aapt resource value: 0x7f0a0031
+			public const int InternetDatabaseResult = 2131361841;
+			
+			// aapt resource value: 0x7f0a0036
+			public const int InternetDatabaseResult_Description = 2131361846;
+			
+			// aapt resource value: 0x7f0a0034
+			public const int InternetDatabaseResult_Image = 2131361844;
+			
+			// aapt resource value: 0x7f0a0032
+			public const int InternetDatabaseResult_Progress = 2131361842;
+			
+			// aapt resource value: 0x7f0a0033
+			public const int InternetDatabaseResult_ProgressText = 2131361843;
+			
+			// aapt resource value: 0x7f0a0098
+			public const int InternetDatabaseResult_Save = 2131361944;
+			
+			// aapt resource value: 0x7f0a0035
+			public const int InternetDatabaseResult_Text = 2131361845;
+			
+			// aapt resource value: 0x7f0a0037
+			public const int Licenses_Text = 2131361847;
+			
+			// aapt resource value: 0x7f0a003f
+			public const int MainButton_Artikeldaten = 2131361855;
+			
+			// aapt resource value: 0x7f0a0040
+			public const int MainButton_Barcode = 2131361856;
+			
+			// aapt resource value: 0x7f0a003d
+			public const int MainButton_Kategorie = 2131361853;
+			
+			// aapt resource value: 0x7f0a003e
+			public const int MainButton_Lagerbestand = 2131361854;
+			
+			// aapt resource value: 0x7f0a0041
+			public const int MainButton_ShoppingList = 2131361857;
+			
+			// aapt resource value: 0x7f0a0038
+			public const int MainLinearLayout = 2131361848;
+			
+			// aapt resource value: 0x7f0a0099
+			public const int Main_Menu_Options = 2131361945;
+			
+			// aapt resource value: 0x7f0a0039
+			public const int Main_Text = 2131361849;
+			
+			// aapt resource value: 0x7f0a003a
+			public const int Main_Text1 = 2131361850;
+			
+			// aapt resource value: 0x7f0a003b
+			public const int Main_Text2 = 2131361851;
+			
+			// aapt resource value: 0x7f0a003c
+			public const int Main_TextInfo = 2131361852;
+			
+			// aapt resource value: 0x7f0a0005
+			public const int ProgressBar = 2131361797;
+			
+			// aapt resource value: 0x7f0a004c
+			public const int ProgressBar_BackupAndRestore = 2131361868;
+			
+			// aapt resource value: 0x7f0a0047
+			public const int ProgressBar_Compress = 2131361863;
+			
+			// aapt resource value: 0x7f0a0050
+			public const int ProgressBar_RestoreSampleDb = 2131361872;
+			
+			// aapt resource value: 0x7f0a0045
+			public const int SelectFile = 2131361861;
+			
+			// aapt resource value: 0x7f0a0043
+			public const int SelectFile_Button = 2131361859;
+			
+			// aapt resource value: 0x7f0a0044
+			public const int SelectFile_Message = 2131361860;
+			
+			// aapt resource value: 0x7f0a0042
+			public const int SelectFile_Path = 2131361858;
+			
+			// aapt resource value: 0x7f0a0056
+			public const int SettingsButton_AdditionalDatabasePath = 2131361878;
+			
+			// aapt resource value: 0x7f0a0057
+			public const int SettingsButton_AltDatePicker = 2131361879;
+			
+			// aapt resource value: 0x7f0a004d
+			public const int SettingsButton_Backup = 2131361869;
+			
+			// aapt resource value: 0x7f0a0048
+			public const int SettingsButton_Compress = 2131361864;
+			
+			// aapt resource value: 0x7f0a0058
+			public const int SettingsButton_CopyAppDbToSdCard = 2131361880;
+			
+			// aapt resource value: 0x7f0a0053
+			public const int SettingsButton_CsvExportArticles = 2131361875;
+			
+			// aapt resource value: 0x7f0a0054
+			public const int SettingsButton_CsvExportStorageItems = 2131361876;
+			
+			// aapt resource value: 0x7f0a0046
+			public const int SettingsButton_DatabasePath = 2131361862;
+			
+			// aapt resource value: 0x7f0a005c
+			public const int SettingsButton_Kontakt = 2131361884;
+			
+			// aapt resource value: 0x7f0a005a
+			public const int SettingsButton_Licenses = 2131361882;
+			
+			// aapt resource value: 0x7f0a0049
+			public const int SettingsButton_Repair = 2131361865;
+			
+			// aapt resource value: 0x7f0a004e
+			public const int SettingsButton_Restore = 2131361870;
+			
+			// aapt resource value: 0x7f0a0052
+			public const int SettingsButton_RestoreDb0 = 2131361874;
+			
+			// aapt resource value: 0x7f0a0051
+			public const int SettingsButton_RestoreSampleDb = 2131361873;
+			
+			// aapt resource value: 0x7f0a0059
+			public const int SettingsButton_SendLogFile = 2131361881;
+			
+			// aapt resource value: 0x7f0a0055
+			public const int SettingsButton_ShowOFFCostMessage = 2131361877;
+			
+			// aapt resource value: 0x7f0a004f
+			public const int SettingsButton_SwitchToTestDB = 2131361871;
+			
+			// aapt resource value: 0x7f0a005b
+			public const int SettingsButton_Version = 2131361883;
+			
+			// aapt resource value: 0x7f0a004b
+			public const int Settings_Categories = 2131361867;
+			
+			// aapt resource value: 0x7f0a004a
+			public const int Settings_Categories_Text = 2131361866;
+			
+			// aapt resource value: 0x7f0a0060
+			public const int ShoppingItemList = 2131361888;
+			
+			// aapt resource value: 0x7f0a0066
+			public const int ShoppingItemListView_Bought = 2131361894;
+			
+			// aapt resource value: 0x7f0a0063
+			public const int ShoppingItemListView_Heading = 2131361891;
+			
+			// aapt resource value: 0x7f0a0061
+			public const int ShoppingItemListView_Image = 2131361889;
+			
+			// aapt resource value: 0x7f0a0065
+			public const int ShoppingItemListView_Quantity = 2131361893;
+			
+			// aapt resource value: 0x7f0a0064
+			public const int ShoppingItemListView_SubHeading = 2131361892;
+			
+			// aapt resource value: 0x7f0a0062
+			public const int ShoppingItemListView_Text = 2131361890;
+			
+			// aapt resource value: 0x7f0a005f
+			public const int ShoppingItemList_Footer = 2131361887;
+			
+			// aapt resource value: 0x7f0a005d
+			public const int ShoppingItemList_SelectSupermarket = 2131361885;
+			
+			// aapt resource value: 0x7f0a005e
+			public const int ShoppingItemList_Spinner = 2131361886;
+			
+			// aapt resource value: 0x7f0a009b
+			public const int ShoppingList_Add = 2131361947;
+			
+			// aapt resource value: 0x7f0a009a
+			public const int ShoppingList_Search = 2131361946;
+			
+			// aapt resource value: 0x7f0a009c
+			public const int ShoppingList_Share = 2131361948;
+			
+			// aapt resource value: 0x7f0a006f
+			public const int SimpleImageViewText = 2131361903;
+			
+			// aapt resource value: 0x7f0a0068
+			public const int SplashScreen_ProgressBar = 2131361896;
+			
+			// aapt resource value: 0x7f0a0067
+			public const int SplashScreen_ProgressText = 2131361895;
+			
+			// aapt resource value: 0x7f0a006e
+			public const int StorageItemListView_Image = 2131361902;
+			
+			// aapt resource value: 0x7f0a0075
+			public const int StorageItemListView_OnShoppingList = 2131361909;
+			
+			// aapt resource value: 0x7f0a0076
+			public const int StorageItemListView_ShoppingQuantity = 2131361910;
+			
+			// aapt resource value: 0x7f0a0071
+			public const int StorageItemListView_TextDetails = 2131361905;
+			
+			// aapt resource value: 0x7f0a0072
+			public const int StorageItemListView_TextError = 2131361906;
+			
+			// aapt resource value: 0x7f0a0070
+			public const int StorageItemListView_TextHeader = 2131361904;
+			
+			// aapt resource value: 0x7f0a0074
+			public const int StorageItemListView_TextInfo = 2131361908;
+			
+			// aapt resource value: 0x7f0a0073
+			public const int StorageItemListView_TextWarning = 2131361907;
+			
+			// aapt resource value: 0x7f0a009f
+			public const int StorageItemList_Add = 2131361951;
+			
+			// aapt resource value: 0x7f0a006c
+			public const int StorageItemList_Footer = 2131361900;
+			
+			// aapt resource value: 0x7f0a009d
+			public const int StorageItemList_Search = 2131361949;
+			
+			// aapt resource value: 0x7f0a0069
+			public const int StorageItemList_SelectStorageSection = 2131361897;
+			
+			// aapt resource value: 0x7f0a00a0
+			public const int StorageItemList_Share = 2131361952;
+			
+			// aapt resource value: 0x7f0a009e
+			public const int StorageItemList_Sort = 2131361950;
+			
+			// aapt resource value: 0x7f0a006b
+			public const int StorageItemList_Storages = 2131361899;
+			
+			// aapt resource value: 0x7f0a006a
+			public const int StorageItemList_TextStorage = 2131361898;
+			
+			// aapt resource value: 0x7f0a0082
+			public const int StorageItemQuantityListView = 2131361922;
+			
+			// aapt resource value: 0x7f0a0083
+			public const int StorageItemQuantityList_Add = 2131361923;
+			
+			// aapt resource value: 0x7f0a0085
+			public const int StorageItemQuantityList_Date = 2131361925;
+			
+			// aapt resource value: 0x7f0a0084
+			public const int StorageItemQuantityList_Quantity = 2131361924;
+			
+			// aapt resource value: 0x7f0a0087
+			public const int StorageItemQuantityList_Remove = 2131361927;
+			
+			// aapt resource value: 0x7f0a0086
+			public const int StorageItemQuantityList_Storage = 2131361926;
+			
+			// aapt resource value: 0x7f0a0081
+			public const int StorageItemQuantity_AddArticle = 2131361921;
+			
+			// aapt resource value: 0x7f0a0079
+			public const int StorageItemQuantity_ArticleDetail = 2131361913;
+			
+			// aapt resource value: 0x7f0a0077
+			public const int StorageItemQuantity_ArticleDetailHeader = 2131361911;
+			
+			// aapt resource value: 0x7f0a00a3
+			public const int StorageItemQuantity_Cancel = 2131361955;
+			
+			// aapt resource value: 0x7f0a00a1
+			public const int StorageItemQuantity_Edit = 2131361953;
+			
+			// aapt resource value: 0x7f0a00a2
+			public const int StorageItemQuantity_EditPicture = 2131361954;
+			
+			// aapt resource value: 0x7f0a0078
+			public const int StorageItemQuantity_Image = 2131361912;
+			
+			// aapt resource value: 0x7f0a00a4
+			public const int StorageItemQuantity_Save = 2131361956;
+			
+			// aapt resource value: 0x7f0a007d
+			public const int StorageItemQuantity_SelectStorage = 2131361917;
+			
+			// aapt resource value: 0x7f0a007e
+			public const int StorageItemQuantity_Step = 2131361918;
+			
+			// aapt resource value: 0x7f0a007f
+			public const int StorageItemQuantity_StepButton = 2131361919;
+			
+			// aapt resource value: 0x7f0a0080
+			public const int StorageItemQuantity_StepText = 2131361920;
+			
+			// aapt resource value: 0x7f0a007a
+			public const int StorageItemQuantity_Storage = 2131361914;
+			
+			// aapt resource value: 0x7f0a007b
+			public const int StorageItemQuantity_StorageLabel = 2131361915;
+			
+			// aapt resource value: 0x7f0a007c
+			public const int StorageItemQuantity_StorageText = 2131361916;
+			
+			// aapt resource value: 0x7f0a00a6
+			public const int StorageItemQuantity_ToArticleDetails = 2131361958;
+			
+			// aapt resource value: 0x7f0a00a5
+			public const int StorageItemQuantity_ToShoppingList = 2131361957;
+			
+			// aapt resource value: 0x7f0a006d
+			public const int StorageItemView = 2131361901;
+			
+			// aapt resource value: 0x7f0a0088
+			public const int contentFrame = 2131361928;
 			
 			// aapt resource value: 0x7f0a0000
 			public const int pd_root = 2131361792;
 			
-			// aapt resource value: 0x7f0a0004
-			public const int scroll = 2131361796;
-			
-			// aapt resource value: 0x7f0a0002
-			public const int textView21 = 2131361794;
+			// aapt resource value: 0x7f0a0001
+			public const int scroll = 2131361793;
 			
 			static Id()
 			{

--- a/Resources/Resource.Designer.cs
+++ b/Resources/Resource.Designer.cs
@@ -209,497 +209,512 @@ namespace VorratsUebersicht
 		public partial class Id
 		{
 			
-			// aapt resource value: 0x7f0a0086
-			public const int ArticleDetailsMenu_Cancel = 2131361926;
-			
-			// aapt resource value: 0x7f0a0088
-			public const int ArticleDetailsMenu_Delete = 2131361928;
-			
-			// aapt resource value: 0x7f0a0090
-			public const int ArticleDetailsMenu_InternetDB = 2131361936;
-			
-			// aapt resource value: 0x7f0a0089
-			public const int ArticleDetailsMenu_MakeAPhoto = 2131361929;
-			
-			// aapt resource value: 0x7f0a0087
-			public const int ArticleDetailsMenu_Save = 2131361927;
-			
-			// aapt resource value: 0x7f0a008c
-			public const int ArticleDetailsMenu_ScanEAN = 2131361932;
-			
-			// aapt resource value: 0x7f0a008a
-			public const int ArticleDetailsMenu_SelectAPicture = 2131361930;
-			
 			// aapt resource value: 0x7f0a008b
-			public const int ArticleDetailsMenu_ShowPicture = 2131361931;
-			
-			// aapt resource value: 0x7f0a008f
-			public const int ArticleDetailsMenu_Speech = 2131361935;
+			public const int ArticleDetailsMenu_Cancel = 2131361931;
 			
 			// aapt resource value: 0x7f0a008d
-			public const int ArticleDetailsMenu_ToShoppingList = 2131361933;
-			
-			// aapt resource value: 0x7f0a008e
-			public const int ArticleDetailsMenu_ToStorageQuantity = 2131361934;
-			
-			// aapt resource value: 0x7f0a001e
-			public const int ArticleDetails_ArticleId = 2131361822;
-			
-			// aapt resource value: 0x7f0a0019
-			public const int ArticleDetails_Calorie = 2131361817;
-			
-			// aapt resource value: 0x7f0a0017
-			public const int ArticleDetails_CaloriePerUnit = 2131361815;
-			
-			// aapt resource value: 0x7f0a0016
-			public const int ArticleDetails_CaloriePerUnitLabel = 2131361814;
-			
-			// aapt resource value: 0x7f0a0015
-			public const int ArticleDetails_CaloriesPerUnitSection = 2131361813;
-			
-			// aapt resource value: 0x7f0a0018
-			public const int ArticleDetails_CaloriesSection = 2131361816;
-			
-			// aapt resource value: 0x7f0a0008
-			public const int ArticleDetails_Category = 2131361800;
-			
-			// aapt resource value: 0x7f0a000f
-			public const int ArticleDetails_DurableInfinity = 2131361807;
-			
-			// aapt resource value: 0x7f0a001c
-			public const int ArticleDetails_EANCode = 2131361820;
-			
-			// aapt resource value: 0x7f0a0001
-			public const int ArticleDetails_Image = 2131361793;
-			
-			// aapt resource value: 0x7f0a0002
-			public const int ArticleDetails_Image2 = 2131361794;
-			
-			// aapt resource value: 0x7f0a0003
-			public const int ArticleDetails_ImageText = 2131361795;
-			
-			// aapt resource value: 0x7f0a0006
-			public const int ArticleDetails_Manufacturer = 2131361798;
-			
-			// aapt resource value: 0x7f0a001a
-			public const int ArticleDetails_MinQuantity = 2131361818;
-			
-			// aapt resource value: 0x7f0a0005
-			public const int ArticleDetails_Name = 2131361797;
-			
-			// aapt resource value: 0x7f0a001d
-			public const int ArticleDetails_Notes = 2131361821;
-			
-			// aapt resource value: 0x7f0a001b
-			public const int ArticleDetails_PrefQuantity = 2131361819;
-			
-			// aapt resource value: 0x7f0a0012
-			public const int ArticleDetails_Price = 2131361810;
-			
-			// aapt resource value: 0x7f0a0007
-			public const int ArticleDetails_SelectManufacturer = 2131361799;
-			
-			// aapt resource value: 0x7f0a000e
-			public const int ArticleDetails_SelectStorage = 2131361806;
-			
-			// aapt resource value: 0x7f0a000a
-			public const int ArticleDetails_SelectSubCategory = 2131361802;
-			
-			// aapt resource value: 0x7f0a000c
-			public const int ArticleDetails_SelectSupermarket = 2131361804;
-			
-			// aapt resource value: 0x7f0a0013
-			public const int ArticleDetails_Size = 2131361811;
-			
-			// aapt resource value: 0x7f0a000d
-			public const int ArticleDetails_Storage = 2131361805;
-			
-			// aapt resource value: 0x7f0a0009
-			public const int ArticleDetails_SubCategory = 2131361801;
-			
-			// aapt resource value: 0x7f0a000b
-			public const int ArticleDetails_Supermarket = 2131361803;
-			
-			// aapt resource value: 0x7f0a0014
-			public const int ArticleDetails_Unit = 2131361812;
-			
-			// aapt resource value: 0x7f0a0011
-			public const int ArticleDetails_WarnInDays = 2131361809;
-			
-			// aapt resource value: 0x7f0a0010
-			public const int ArticleDetails_WarnInDaysLabel = 2131361808;
-			
-			// aapt resource value: 0x7f0a0091
-			public const int ArticleImageMenu_RotateRight = 2131361937;
-			
-			// aapt resource value: 0x7f0a0021
-			public const int ArticleImage_Image = 2131361825;
-			
-			// aapt resource value: 0x7f0a0020
-			public const int ArticleImage_Info = 2131361824;
-			
-			// aapt resource value: 0x7f0a001f
-			public const int ArticleImage_ProgressBar = 2131361823;
-			
-			// aapt resource value: 0x7f0a0026
-			public const int ArticleList = 2131361830;
-			
-			// aapt resource value: 0x7f0a0029
-			public const int ArticleListView_Heading = 2131361833;
-			
-			// aapt resource value: 0x7f0a0027
-			public const int ArticleListView_Image = 2131361831;
-			
-			// aapt resource value: 0x7f0a002b
-			public const int ArticleListView_IsInStorage = 2131361835;
-			
-			// aapt resource value: 0x7f0a002f
-			public const int ArticleListView_Notes = 2131361839;
-			
-			// aapt resource value: 0x7f0a002d
-			public const int ArticleListView_OnShoppingList = 2131361837;
-			
-			// aapt resource value: 0x7f0a002e
-			public const int ArticleListView_ShoppingQuantity = 2131361838;
-			
-			// aapt resource value: 0x7f0a002c
-			public const int ArticleListView_StorageQuantity = 2131361836;
-			
-			// aapt resource value: 0x7f0a002a
-			public const int ArticleListView_SubHeading = 2131361834;
-			
-			// aapt resource value: 0x7f0a0028
-			public const int ArticleListView_Text = 2131361832;
-			
-			// aapt resource value: 0x7f0a0093
-			public const int ArticleList_Add = 2131361939;
-			
-			// aapt resource value: 0x7f0a0024
-			public const int ArticleList_Categories = 2131361828;
-			
-			// aapt resource value: 0x7f0a0023
-			public const int ArticleList_Category = 2131361827;
-			
-			// aapt resource value: 0x7f0a0025
-			public const int ArticleList_Footer = 2131361829;
-			
-			// aapt resource value: 0x7f0a0092
-			public const int ArticleList_Search = 2131361938;
-			
-			// aapt resource value: 0x7f0a0022
-			public const int ArticleList_SelectCategory = 2131361826;
-			
-			// aapt resource value: 0x7f0a0094
-			public const int ArticleList_Share = 2131361940;
-			
-			// aapt resource value: 0x7f0a0030
-			public const int InternetDatabaseResult = 2131361840;
-			
-			// aapt resource value: 0x7f0a0035
-			public const int InternetDatabaseResult_Description = 2131361845;
-			
-			// aapt resource value: 0x7f0a0033
-			public const int InternetDatabaseResult_Image = 2131361843;
-			
-			// aapt resource value: 0x7f0a0031
-			public const int InternetDatabaseResult_Progress = 2131361841;
-			
-			// aapt resource value: 0x7f0a0032
-			public const int InternetDatabaseResult_ProgressText = 2131361842;
+			public const int ArticleDetailsMenu_Delete = 2131361933;
 			
 			// aapt resource value: 0x7f0a0095
-			public const int InternetDatabaseResult_Save = 2131361941;
+			public const int ArticleDetailsMenu_InternetDB = 2131361941;
 			
-			// aapt resource value: 0x7f0a0034
-			public const int InternetDatabaseResult_Text = 2131361844;
+			// aapt resource value: 0x7f0a008e
+			public const int ArticleDetailsMenu_MakeAPhoto = 2131361934;
 			
-			// aapt resource value: 0x7f0a0036
-			public const int Licenses_Text = 2131361846;
+			// aapt resource value: 0x7f0a008c
+			public const int ArticleDetailsMenu_Save = 2131361932;
 			
-			// aapt resource value: 0x7f0a003d
-			public const int MainButton_Artikeldaten = 2131361853;
+			// aapt resource value: 0x7f0a0091
+			public const int ArticleDetailsMenu_ScanEAN = 2131361937;
 			
-			// aapt resource value: 0x7f0a003e
-			public const int MainButton_Barcode = 2131361854;
+			// aapt resource value: 0x7f0a008f
+			public const int ArticleDetailsMenu_SelectAPicture = 2131361935;
 			
-			// aapt resource value: 0x7f0a003b
-			public const int MainButton_Kategorie = 2131361851;
+			// aapt resource value: 0x7f0a0090
+			public const int ArticleDetailsMenu_ShowPicture = 2131361936;
 			
-			// aapt resource value: 0x7f0a003c
-			public const int MainButton_Lagerbestand = 2131361852;
+			// aapt resource value: 0x7f0a0094
+			public const int ArticleDetailsMenu_Speech = 2131361940;
 			
-			// aapt resource value: 0x7f0a003f
-			public const int MainButton_ShoppingList = 2131361855;
+			// aapt resource value: 0x7f0a0092
+			public const int ArticleDetailsMenu_ToShoppingList = 2131361938;
+			
+			// aapt resource value: 0x7f0a0093
+			public const int ArticleDetailsMenu_ToStorageQuantity = 2131361939;
+			
+			// aapt resource value: 0x7f0a0022
+			public const int ArticleDetails_ArticleId = 2131361826;
+			
+			// aapt resource value: 0x7f0a001d
+			public const int ArticleDetails_Calorie = 2131361821;
+			
+			// aapt resource value: 0x7f0a001b
+			public const int ArticleDetails_CaloriePerUnit = 2131361819;
+			
+			// aapt resource value: 0x7f0a001a
+			public const int ArticleDetails_CaloriePerUnitLabel = 2131361818;
+			
+			// aapt resource value: 0x7f0a0019
+			public const int ArticleDetails_CaloriesPerUnitSection = 2131361817;
+			
+			// aapt resource value: 0x7f0a001c
+			public const int ArticleDetails_CaloriesSection = 2131361820;
+			
+			// aapt resource value: 0x7f0a000c
+			public const int ArticleDetails_Category = 2131361804;
+			
+			// aapt resource value: 0x7f0a0013
+			public const int ArticleDetails_DurableInfinity = 2131361811;
+			
+			// aapt resource value: 0x7f0a0020
+			public const int ArticleDetails_EANCode = 2131361824;
+			
+			// aapt resource value: 0x7f0a0005
+			public const int ArticleDetails_Image = 2131361797;
+			
+			// aapt resource value: 0x7f0a0006
+			public const int ArticleDetails_Image2 = 2131361798;
+			
+			// aapt resource value: 0x7f0a0007
+			public const int ArticleDetails_ImageText = 2131361799;
+			
+			// aapt resource value: 0x7f0a000a
+			public const int ArticleDetails_Manufacturer = 2131361802;
+			
+			// aapt resource value: 0x7f0a001e
+			public const int ArticleDetails_MinQuantity = 2131361822;
+			
+			// aapt resource value: 0x7f0a0009
+			public const int ArticleDetails_Name = 2131361801;
+			
+			// aapt resource value: 0x7f0a0021
+			public const int ArticleDetails_Notes = 2131361825;
+			
+			// aapt resource value: 0x7f0a001f
+			public const int ArticleDetails_PrefQuantity = 2131361823;
+			
+			// aapt resource value: 0x7f0a0016
+			public const int ArticleDetails_Price = 2131361814;
+			
+			// aapt resource value: 0x7f0a000b
+			public const int ArticleDetails_SelectManufacturer = 2131361803;
+			
+			// aapt resource value: 0x7f0a0012
+			public const int ArticleDetails_SelectStorage = 2131361810;
+			
+			// aapt resource value: 0x7f0a000e
+			public const int ArticleDetails_SelectSubCategory = 2131361806;
+			
+			// aapt resource value: 0x7f0a0010
+			public const int ArticleDetails_SelectSupermarket = 2131361808;
+			
+			// aapt resource value: 0x7f0a0017
+			public const int ArticleDetails_Size = 2131361815;
+			
+			// aapt resource value: 0x7f0a0011
+			public const int ArticleDetails_Storage = 2131361809;
+			
+			// aapt resource value: 0x7f0a000d
+			public const int ArticleDetails_SubCategory = 2131361805;
+			
+			// aapt resource value: 0x7f0a000f
+			public const int ArticleDetails_Supermarket = 2131361807;
+			
+			// aapt resource value: 0x7f0a0018
+			public const int ArticleDetails_Unit = 2131361816;
+			
+			// aapt resource value: 0x7f0a0015
+			public const int ArticleDetails_WarnInDays = 2131361813;
+			
+			// aapt resource value: 0x7f0a0014
+			public const int ArticleDetails_WarnInDaysLabel = 2131361812;
 			
 			// aapt resource value: 0x7f0a0096
-			public const int Main_Menu_Options = 2131361942;
+			public const int ArticleImageMenu_RotateRight = 2131361942;
 			
-			// aapt resource value: 0x7f0a0037
-			public const int Main_Text = 2131361847;
+			// aapt resource value: 0x7f0a0025
+			public const int ArticleImage_Image = 2131361829;
 			
-			// aapt resource value: 0x7f0a0038
-			public const int Main_Text1 = 2131361848;
+			// aapt resource value: 0x7f0a0024
+			public const int ArticleImage_Info = 2131361828;
 			
-			// aapt resource value: 0x7f0a0039
-			public const int Main_Text2 = 2131361849;
+			// aapt resource value: 0x7f0a0023
+			public const int ArticleImage_ProgressBar = 2131361827;
 			
-			// aapt resource value: 0x7f0a003a
-			public const int Main_TextInfo = 2131361850;
+			// aapt resource value: 0x7f0a002a
+			public const int ArticleList = 2131361834;
 			
-			// aapt resource value: 0x7f0a0004
-			public const int ProgressBar = 2131361796;
+			// aapt resource value: 0x7f0a002d
+			public const int ArticleListView_Heading = 2131361837;
 			
-			// aapt resource value: 0x7f0a004a
-			public const int ProgressBar_BackupAndRestore = 2131361866;
+			// aapt resource value: 0x7f0a002b
+			public const int ArticleListView_Image = 2131361835;
 			
-			// aapt resource value: 0x7f0a0045
-			public const int ProgressBar_Compress = 2131361861;
+			// aapt resource value: 0x7f0a002f
+			public const int ArticleListView_IsInStorage = 2131361839;
 			
-			// aapt resource value: 0x7f0a004e
-			public const int ProgressBar_RestoreSampleDb = 2131361870;
+			// aapt resource value: 0x7f0a0033
+			public const int ArticleListView_Notes = 2131361843;
 			
-			// aapt resource value: 0x7f0a0043
-			public const int SelectFile = 2131361859;
+			// aapt resource value: 0x7f0a0031
+			public const int ArticleListView_OnShoppingList = 2131361841;
 			
-			// aapt resource value: 0x7f0a0041
-			public const int SelectFile_Button = 2131361857;
+			// aapt resource value: 0x7f0a0032
+			public const int ArticleListView_ShoppingQuantity = 2131361842;
 			
-			// aapt resource value: 0x7f0a0042
-			public const int SelectFile_Message = 2131361858;
+			// aapt resource value: 0x7f0a0030
+			public const int ArticleListView_StorageQuantity = 2131361840;
 			
-			// aapt resource value: 0x7f0a0040
-			public const int SelectFile_Path = 2131361856;
+			// aapt resource value: 0x7f0a002e
+			public const int ArticleListView_SubHeading = 2131361838;
 			
-			// aapt resource value: 0x7f0a0054
-			public const int SettingsButton_AdditionalDatabasePath = 2131361876;
-			
-			// aapt resource value: 0x7f0a004b
-			public const int SettingsButton_Backup = 2131361867;
-			
-			// aapt resource value: 0x7f0a0046
-			public const int SettingsButton_Compress = 2131361862;
-			
-			// aapt resource value: 0x7f0a0055
-			public const int SettingsButton_CopyAppDbToSdCard = 2131361877;
-			
-			// aapt resource value: 0x7f0a0051
-			public const int SettingsButton_CsvExportArticles = 2131361873;
-			
-			// aapt resource value: 0x7f0a0052
-			public const int SettingsButton_CsvExportStorageItems = 2131361874;
-			
-			// aapt resource value: 0x7f0a0044
-			public const int SettingsButton_DatabasePath = 2131361860;
-			
-			// aapt resource value: 0x7f0a0059
-			public const int SettingsButton_Kontakt = 2131361881;
-			
-			// aapt resource value: 0x7f0a0057
-			public const int SettingsButton_Licenses = 2131361879;
-			
-			// aapt resource value: 0x7f0a0047
-			public const int SettingsButton_Repair = 2131361863;
-			
-			// aapt resource value: 0x7f0a004c
-			public const int SettingsButton_Restore = 2131361868;
-			
-			// aapt resource value: 0x7f0a0050
-			public const int SettingsButton_RestoreDb0 = 2131361872;
-			
-			// aapt resource value: 0x7f0a004f
-			public const int SettingsButton_RestoreSampleDb = 2131361871;
-			
-			// aapt resource value: 0x7f0a0056
-			public const int SettingsButton_SendLogFile = 2131361878;
-			
-			// aapt resource value: 0x7f0a0053
-			public const int SettingsButton_ShowOFFCostMessage = 2131361875;
-			
-			// aapt resource value: 0x7f0a004d
-			public const int SettingsButton_SwitchToTestDB = 2131361869;
-			
-			// aapt resource value: 0x7f0a0058
-			public const int SettingsButton_Version = 2131361880;
-			
-			// aapt resource value: 0x7f0a0049
-			public const int Settings_Categories = 2131361865;
-			
-			// aapt resource value: 0x7f0a0048
-			public const int Settings_Categories_Text = 2131361864;
-			
-			// aapt resource value: 0x7f0a005d
-			public const int ShoppingItemList = 2131361885;
-			
-			// aapt resource value: 0x7f0a0063
-			public const int ShoppingItemListView_Bought = 2131361891;
-			
-			// aapt resource value: 0x7f0a0060
-			public const int ShoppingItemListView_Heading = 2131361888;
-			
-			// aapt resource value: 0x7f0a005e
-			public const int ShoppingItemListView_Image = 2131361886;
-			
-			// aapt resource value: 0x7f0a0062
-			public const int ShoppingItemListView_Quantity = 2131361890;
-			
-			// aapt resource value: 0x7f0a0061
-			public const int ShoppingItemListView_SubHeading = 2131361889;
-			
-			// aapt resource value: 0x7f0a005f
-			public const int ShoppingItemListView_Text = 2131361887;
-			
-			// aapt resource value: 0x7f0a005c
-			public const int ShoppingItemList_Footer = 2131361884;
-			
-			// aapt resource value: 0x7f0a005a
-			public const int ShoppingItemList_SelectSupermarket = 2131361882;
-			
-			// aapt resource value: 0x7f0a005b
-			public const int ShoppingItemList_Spinner = 2131361883;
+			// aapt resource value: 0x7f0a002c
+			public const int ArticleListView_Text = 2131361836;
 			
 			// aapt resource value: 0x7f0a0098
-			public const int ShoppingList_Add = 2131361944;
+			public const int ArticleList_Add = 2131361944;
+			
+			// aapt resource value: 0x7f0a0028
+			public const int ArticleList_Categories = 2131361832;
+			
+			// aapt resource value: 0x7f0a0027
+			public const int ArticleList_Category = 2131361831;
+			
+			// aapt resource value: 0x7f0a0029
+			public const int ArticleList_Footer = 2131361833;
 			
 			// aapt resource value: 0x7f0a0097
-			public const int ShoppingList_Search = 2131361943;
+			public const int ArticleList_Search = 2131361943;
+			
+			// aapt resource value: 0x7f0a0026
+			public const int ArticleList_SelectCategory = 2131361830;
 			
 			// aapt resource value: 0x7f0a0099
-			public const int ShoppingList_Share = 2131361945;
+			public const int ArticleList_Share = 2131361945;
 			
-			// aapt resource value: 0x7f0a006c
-			public const int SimpleImageViewText = 2131361900;
+			// aapt resource value: 0x7f0a0034
+			public const int InternetDatabaseResult = 2131361844;
 			
-			// aapt resource value: 0x7f0a0065
-			public const int SplashScreen_ProgressBar = 2131361893;
+			// aapt resource value: 0x7f0a0039
+			public const int InternetDatabaseResult_Description = 2131361849;
 			
-			// aapt resource value: 0x7f0a0064
-			public const int SplashScreen_ProgressText = 2131361892;
+			// aapt resource value: 0x7f0a0037
+			public const int InternetDatabaseResult_Image = 2131361847;
 			
-			// aapt resource value: 0x7f0a006b
-			public const int StorageItemListView_Image = 2131361899;
+			// aapt resource value: 0x7f0a0035
+			public const int InternetDatabaseResult_Progress = 2131361845;
 			
-			// aapt resource value: 0x7f0a0072
-			public const int StorageItemListView_OnShoppingList = 2131361906;
-			
-			// aapt resource value: 0x7f0a0073
-			public const int StorageItemListView_ShoppingQuantity = 2131361907;
-			
-			// aapt resource value: 0x7f0a006e
-			public const int StorageItemListView_TextDetails = 2131361902;
-			
-			// aapt resource value: 0x7f0a006f
-			public const int StorageItemListView_TextError = 2131361903;
-			
-			// aapt resource value: 0x7f0a006d
-			public const int StorageItemListView_TextHeader = 2131361901;
-			
-			// aapt resource value: 0x7f0a0071
-			public const int StorageItemListView_TextInfo = 2131361905;
-			
-			// aapt resource value: 0x7f0a0070
-			public const int StorageItemListView_TextWarning = 2131361904;
-			
-			// aapt resource value: 0x7f0a009c
-			public const int StorageItemList_Add = 2131361948;
-			
-			// aapt resource value: 0x7f0a0069
-			public const int StorageItemList_Footer = 2131361897;
+			// aapt resource value: 0x7f0a0036
+			public const int InternetDatabaseResult_ProgressText = 2131361846;
 			
 			// aapt resource value: 0x7f0a009a
-			public const int StorageItemList_Search = 2131361946;
+			public const int InternetDatabaseResult_Save = 2131361946;
 			
-			// aapt resource value: 0x7f0a0066
-			public const int StorageItemList_SelectStorageSection = 2131361894;
+			// aapt resource value: 0x7f0a0038
+			public const int InternetDatabaseResult_Text = 2131361848;
 			
-			// aapt resource value: 0x7f0a009d
-			public const int StorageItemList_Share = 2131361949;
+			// aapt resource value: 0x7f0a003a
+			public const int Licenses_Text = 2131361850;
+			
+			// aapt resource value: 0x7f0a0041
+			public const int MainButton_Artikeldaten = 2131361857;
+			
+			// aapt resource value: 0x7f0a0042
+			public const int MainButton_Barcode = 2131361858;
+			
+			// aapt resource value: 0x7f0a003f
+			public const int MainButton_Kategorie = 2131361855;
+			
+			// aapt resource value: 0x7f0a0040
+			public const int MainButton_Lagerbestand = 2131361856;
+			
+			// aapt resource value: 0x7f0a0043
+			public const int MainButton_ShoppingList = 2131361859;
 			
 			// aapt resource value: 0x7f0a009b
-			public const int StorageItemList_Sort = 2131361947;
+			public const int Main_Menu_Options = 2131361947;
+			
+			// aapt resource value: 0x7f0a003b
+			public const int Main_Text = 2131361851;
+			
+			// aapt resource value: 0x7f0a003c
+			public const int Main_Text1 = 2131361852;
+			
+			// aapt resource value: 0x7f0a003d
+			public const int Main_Text2 = 2131361853;
+			
+			// aapt resource value: 0x7f0a003e
+			public const int Main_TextInfo = 2131361854;
+			
+			// aapt resource value: 0x7f0a0008
+			public const int ProgressBar = 2131361800;
+			
+			// aapt resource value: 0x7f0a004e
+			public const int ProgressBar_BackupAndRestore = 2131361870;
+			
+			// aapt resource value: 0x7f0a0049
+			public const int ProgressBar_Compress = 2131361865;
+			
+			// aapt resource value: 0x7f0a0052
+			public const int ProgressBar_RestoreSampleDb = 2131361874;
+			
+			// aapt resource value: 0x7f0a0047
+			public const int SelectFile = 2131361863;
+			
+			// aapt resource value: 0x7f0a0045
+			public const int SelectFile_Button = 2131361861;
+			
+			// aapt resource value: 0x7f0a0046
+			public const int SelectFile_Message = 2131361862;
+			
+			// aapt resource value: 0x7f0a0044
+			public const int SelectFile_Path = 2131361860;
+			
+			// aapt resource value: 0x7f0a0058
+			public const int SettingsButton_AdditionalDatabasePath = 2131361880;
+			
+			// aapt resource value: 0x7f0a0059
+			public const int SettingsButton_AltDatePicker = 2131361881;
+			
+			// aapt resource value: 0x7f0a004f
+			public const int SettingsButton_Backup = 2131361871;
+			
+			// aapt resource value: 0x7f0a004a
+			public const int SettingsButton_Compress = 2131361866;
+			
+			// aapt resource value: 0x7f0a005a
+			public const int SettingsButton_CopyAppDbToSdCard = 2131361882;
+			
+			// aapt resource value: 0x7f0a0055
+			public const int SettingsButton_CsvExportArticles = 2131361877;
+			
+			// aapt resource value: 0x7f0a0056
+			public const int SettingsButton_CsvExportStorageItems = 2131361878;
+			
+			// aapt resource value: 0x7f0a0048
+			public const int SettingsButton_DatabasePath = 2131361864;
+			
+			// aapt resource value: 0x7f0a005e
+			public const int SettingsButton_Kontakt = 2131361886;
+			
+			// aapt resource value: 0x7f0a005c
+			public const int SettingsButton_Licenses = 2131361884;
+			
+			// aapt resource value: 0x7f0a004b
+			public const int SettingsButton_Repair = 2131361867;
+			
+			// aapt resource value: 0x7f0a0050
+			public const int SettingsButton_Restore = 2131361872;
+			
+			// aapt resource value: 0x7f0a0054
+			public const int SettingsButton_RestoreDb0 = 2131361876;
+			
+			// aapt resource value: 0x7f0a0053
+			public const int SettingsButton_RestoreSampleDb = 2131361875;
+			
+			// aapt resource value: 0x7f0a005b
+			public const int SettingsButton_SendLogFile = 2131361883;
+			
+			// aapt resource value: 0x7f0a0057
+			public const int SettingsButton_ShowOFFCostMessage = 2131361879;
+			
+			// aapt resource value: 0x7f0a0051
+			public const int SettingsButton_SwitchToTestDB = 2131361873;
+			
+			// aapt resource value: 0x7f0a005d
+			public const int SettingsButton_Version = 2131361885;
+			
+			// aapt resource value: 0x7f0a004d
+			public const int Settings_Categories = 2131361869;
+			
+			// aapt resource value: 0x7f0a004c
+			public const int Settings_Categories_Text = 2131361868;
+			
+			// aapt resource value: 0x7f0a0062
+			public const int ShoppingItemList = 2131361890;
 			
 			// aapt resource value: 0x7f0a0068
-			public const int StorageItemList_Storages = 2131361896;
+			public const int ShoppingItemListView_Bought = 2131361896;
+			
+			// aapt resource value: 0x7f0a0065
+			public const int ShoppingItemListView_Heading = 2131361893;
+			
+			// aapt resource value: 0x7f0a0063
+			public const int ShoppingItemListView_Image = 2131361891;
 			
 			// aapt resource value: 0x7f0a0067
-			public const int StorageItemList_TextStorage = 2131361895;
+			public const int ShoppingItemListView_Quantity = 2131361895;
 			
-			// aapt resource value: 0x7f0a007f
-			public const int StorageItemQuantityListView = 2131361919;
+			// aapt resource value: 0x7f0a0066
+			public const int ShoppingItemListView_SubHeading = 2131361894;
 			
-			// aapt resource value: 0x7f0a0080
-			public const int StorageItemQuantityList_Add = 2131361920;
+			// aapt resource value: 0x7f0a0064
+			public const int ShoppingItemListView_Text = 2131361892;
 			
-			// aapt resource value: 0x7f0a0082
-			public const int StorageItemQuantityList_Date = 2131361922;
+			// aapt resource value: 0x7f0a0061
+			public const int ShoppingItemList_Footer = 2131361889;
 			
-			// aapt resource value: 0x7f0a0081
-			public const int StorageItemQuantityList_Quantity = 2131361921;
+			// aapt resource value: 0x7f0a005f
+			public const int ShoppingItemList_SelectSupermarket = 2131361887;
 			
-			// aapt resource value: 0x7f0a0084
-			public const int StorageItemQuantityList_Remove = 2131361924;
+			// aapt resource value: 0x7f0a0060
+			public const int ShoppingItemList_Spinner = 2131361888;
 			
-			// aapt resource value: 0x7f0a0083
-			public const int StorageItemQuantityList_Storage = 2131361923;
+			// aapt resource value: 0x7f0a009d
+			public const int ShoppingList_Add = 2131361949;
 			
-			// aapt resource value: 0x7f0a007e
-			public const int StorageItemQuantity_AddArticle = 2131361918;
-			
-			// aapt resource value: 0x7f0a0076
-			public const int StorageItemQuantity_ArticleDetail = 2131361910;
-			
-			// aapt resource value: 0x7f0a0074
-			public const int StorageItemQuantity_ArticleDetailHeader = 2131361908;
-			
-			// aapt resource value: 0x7f0a00a0
-			public const int StorageItemQuantity_Cancel = 2131361952;
+			// aapt resource value: 0x7f0a009c
+			public const int ShoppingList_Search = 2131361948;
 			
 			// aapt resource value: 0x7f0a009e
-			public const int StorageItemQuantity_Edit = 2131361950;
+			public const int ShoppingList_Share = 2131361950;
 			
-			// aapt resource value: 0x7f0a009f
-			public const int StorageItemQuantity_EditPicture = 2131361951;
-			
-			// aapt resource value: 0x7f0a0075
-			public const int StorageItemQuantity_Image = 2131361909;
-			
-			// aapt resource value: 0x7f0a00a1
-			public const int StorageItemQuantity_Save = 2131361953;
-			
-			// aapt resource value: 0x7f0a007a
-			public const int StorageItemQuantity_SelectStorage = 2131361914;
-			
-			// aapt resource value: 0x7f0a007b
-			public const int StorageItemQuantity_Step = 2131361915;
-			
-			// aapt resource value: 0x7f0a007c
-			public const int StorageItemQuantity_StepButton = 2131361916;
-			
-			// aapt resource value: 0x7f0a007d
-			public const int StorageItemQuantity_StepText = 2131361917;
-			
-			// aapt resource value: 0x7f0a0077
-			public const int StorageItemQuantity_Storage = 2131361911;
-			
-			// aapt resource value: 0x7f0a0078
-			public const int StorageItemQuantity_StorageLabel = 2131361912;
-			
-			// aapt resource value: 0x7f0a0079
-			public const int StorageItemQuantity_StorageText = 2131361913;
-			
-			// aapt resource value: 0x7f0a00a3
-			public const int StorageItemQuantity_ToArticleDetails = 2131361955;
-			
-			// aapt resource value: 0x7f0a00a2
-			public const int StorageItemQuantity_ToShoppingList = 2131361954;
+			// aapt resource value: 0x7f0a0071
+			public const int SimpleImageViewText = 2131361905;
 			
 			// aapt resource value: 0x7f0a006a
-			public const int StorageItemView = 2131361898;
+			public const int SplashScreen_ProgressBar = 2131361898;
+			
+			// aapt resource value: 0x7f0a0069
+			public const int SplashScreen_ProgressText = 2131361897;
+			
+			// aapt resource value: 0x7f0a0070
+			public const int StorageItemListView_Image = 2131361904;
+			
+			// aapt resource value: 0x7f0a0077
+			public const int StorageItemListView_OnShoppingList = 2131361911;
+			
+			// aapt resource value: 0x7f0a0078
+			public const int StorageItemListView_ShoppingQuantity = 2131361912;
+			
+			// aapt resource value: 0x7f0a0073
+			public const int StorageItemListView_TextDetails = 2131361907;
+			
+			// aapt resource value: 0x7f0a0074
+			public const int StorageItemListView_TextError = 2131361908;
+			
+			// aapt resource value: 0x7f0a0072
+			public const int StorageItemListView_TextHeader = 2131361906;
+			
+			// aapt resource value: 0x7f0a0076
+			public const int StorageItemListView_TextInfo = 2131361910;
+			
+			// aapt resource value: 0x7f0a0075
+			public const int StorageItemListView_TextWarning = 2131361909;
+			
+			// aapt resource value: 0x7f0a00a1
+			public const int StorageItemList_Add = 2131361953;
+			
+			// aapt resource value: 0x7f0a006e
+			public const int StorageItemList_Footer = 2131361902;
+			
+			// aapt resource value: 0x7f0a009f
+			public const int StorageItemList_Search = 2131361951;
+			
+			// aapt resource value: 0x7f0a006b
+			public const int StorageItemList_SelectStorageSection = 2131361899;
+			
+			// aapt resource value: 0x7f0a00a2
+			public const int StorageItemList_Share = 2131361954;
+			
+			// aapt resource value: 0x7f0a00a0
+			public const int StorageItemList_Sort = 2131361952;
+			
+			// aapt resource value: 0x7f0a006d
+			public const int StorageItemList_Storages = 2131361901;
+			
+			// aapt resource value: 0x7f0a006c
+			public const int StorageItemList_TextStorage = 2131361900;
+			
+			// aapt resource value: 0x7f0a0084
+			public const int StorageItemQuantityListView = 2131361924;
 			
 			// aapt resource value: 0x7f0a0085
-			public const int contentFrame = 2131361925;
+			public const int StorageItemQuantityList_Add = 2131361925;
+			
+			// aapt resource value: 0x7f0a0087
+			public const int StorageItemQuantityList_Date = 2131361927;
+			
+			// aapt resource value: 0x7f0a0086
+			public const int StorageItemQuantityList_Quantity = 2131361926;
+			
+			// aapt resource value: 0x7f0a0089
+			public const int StorageItemQuantityList_Remove = 2131361929;
+			
+			// aapt resource value: 0x7f0a0088
+			public const int StorageItemQuantityList_Storage = 2131361928;
+			
+			// aapt resource value: 0x7f0a0083
+			public const int StorageItemQuantity_AddArticle = 2131361923;
+			
+			// aapt resource value: 0x7f0a007b
+			public const int StorageItemQuantity_ArticleDetail = 2131361915;
+			
+			// aapt resource value: 0x7f0a0079
+			public const int StorageItemQuantity_ArticleDetailHeader = 2131361913;
+			
+			// aapt resource value: 0x7f0a00a5
+			public const int StorageItemQuantity_Cancel = 2131361957;
+			
+			// aapt resource value: 0x7f0a00a3
+			public const int StorageItemQuantity_Edit = 2131361955;
+			
+			// aapt resource value: 0x7f0a00a4
+			public const int StorageItemQuantity_EditPicture = 2131361956;
+			
+			// aapt resource value: 0x7f0a007a
+			public const int StorageItemQuantity_Image = 2131361914;
+			
+			// aapt resource value: 0x7f0a00a6
+			public const int StorageItemQuantity_Save = 2131361958;
+			
+			// aapt resource value: 0x7f0a007f
+			public const int StorageItemQuantity_SelectStorage = 2131361919;
+			
+			// aapt resource value: 0x7f0a0080
+			public const int StorageItemQuantity_Step = 2131361920;
+			
+			// aapt resource value: 0x7f0a0081
+			public const int StorageItemQuantity_StepButton = 2131361921;
+			
+			// aapt resource value: 0x7f0a0082
+			public const int StorageItemQuantity_StepText = 2131361922;
+			
+			// aapt resource value: 0x7f0a007c
+			public const int StorageItemQuantity_Storage = 2131361916;
+			
+			// aapt resource value: 0x7f0a007d
+			public const int StorageItemQuantity_StorageLabel = 2131361917;
+			
+			// aapt resource value: 0x7f0a007e
+			public const int StorageItemQuantity_StorageText = 2131361918;
+			
+			// aapt resource value: 0x7f0a00a8
+			public const int StorageItemQuantity_ToArticleDetails = 2131361960;
+			
+			// aapt resource value: 0x7f0a00a7
+			public const int StorageItemQuantity_ToShoppingList = 2131361959;
+			
+			// aapt resource value: 0x7f0a006f
+			public const int StorageItemView = 2131361903;
+			
+			// aapt resource value: 0x7f0a0001
+			public const int button1 = 2131361793;
+			
+			// aapt resource value: 0x7f0a0003
+			public const int button2 = 2131361795;
+			
+			// aapt resource value: 0x7f0a008a
+			public const int contentFrame = 2131361930;
 			
 			// aapt resource value: 0x7f0a0000
-			public const int scroll = 2131361792;
+			public const int pd_root = 2131361792;
+			
+			// aapt resource value: 0x7f0a0004
+			public const int scroll = 2131361796;
+			
+			// aapt resource value: 0x7f0a0002
+			public const int textView21 = 2131361794;
 			
 			static Id()
 			{
@@ -715,58 +730,61 @@ namespace VorratsUebersicht
 		{
 			
 			// aapt resource value: 0x7f030000
-			public const int ArticleDetails = 2130903040;
+			public const int AltDatePickerFragment = 2130903040;
 			
 			// aapt resource value: 0x7f030001
-			public const int ArticleImage = 2130903041;
+			public const int ArticleDetails = 2130903041;
 			
 			// aapt resource value: 0x7f030002
-			public const int ArticleList = 2130903042;
+			public const int ArticleImage = 2130903042;
 			
 			// aapt resource value: 0x7f030003
-			public const int ArticleListView = 2130903043;
+			public const int ArticleList = 2130903043;
 			
 			// aapt resource value: 0x7f030004
-			public const int InternetDatabaseSearch = 2130903044;
+			public const int ArticleListView = 2130903044;
 			
 			// aapt resource value: 0x7f030005
-			public const int Licenses = 2130903045;
+			public const int InternetDatabaseSearch = 2130903045;
 			
 			// aapt resource value: 0x7f030006
-			public const int Main = 2130903046;
+			public const int Licenses = 2130903046;
 			
 			// aapt resource value: 0x7f030007
-			public const int SelectFile = 2130903047;
+			public const int Main = 2130903047;
 			
 			// aapt resource value: 0x7f030008
-			public const int Settings = 2130903048;
+			public const int SelectFile = 2130903048;
 			
 			// aapt resource value: 0x7f030009
-			public const int ShoppingItemList = 2130903049;
+			public const int Settings = 2130903049;
 			
 			// aapt resource value: 0x7f03000a
-			public const int ShoppingItemListView = 2130903050;
+			public const int ShoppingItemList = 2130903050;
 			
 			// aapt resource value: 0x7f03000b
-			public const int SplashScreen = 2130903051;
+			public const int ShoppingItemListView = 2130903051;
 			
 			// aapt resource value: 0x7f03000c
-			public const int StorageItemList = 2130903052;
+			public const int SplashScreen = 2130903052;
 			
 			// aapt resource value: 0x7f03000d
-			public const int StorageItemListView = 2130903053;
+			public const int StorageItemList = 2130903053;
 			
 			// aapt resource value: 0x7f03000e
-			public const int StorageItemQuantity = 2130903054;
+			public const int StorageItemListView = 2130903054;
 			
 			// aapt resource value: 0x7f03000f
-			public const int StorageItemQuantityListView = 2130903055;
+			public const int StorageItemQuantity = 2130903055;
 			
 			// aapt resource value: 0x7f030010
-			public const int zxingscanneractivitylayout = 2130903056;
+			public const int StorageItemQuantityListView = 2130903056;
 			
 			// aapt resource value: 0x7f030011
-			public const int zxingscannerfragmentlayout = 2130903057;
+			public const int zxingscanneractivitylayout = 2130903057;
+			
+			// aapt resource value: 0x7f030012
+			public const int zxingscannerfragmentlayout = 2130903058;
 			
 			static Layout()
 			{

--- a/Resources/layout/AltDatePickerFragment.axml
+++ b/Resources/layout/AltDatePickerFragment.axml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  android:orientation=    "vertical"
+  android:layout_width=    "match_parent"
+  android:layout_height=    "wrap_content"
+  android:id="@+id/pd_root"
+  android:minWidth="25px"
+  android:minHeight="25px"
+  android:padding="3px" 
+  android:weightSum="3"
+ 
+  >
+  <Button
+    android:text="Button"
+    android:layout_width="0dp"
+    android:layout_weight="1"
+    android:layout_height="wrap_content"
+    android:id="@+id/button1" />
+  <TextView
+    android:text="Medium Text"
+    android:textAppearance="?android:attr/textAppearanceLarge"
+    android:layout_width="0dp"
+    android:layout_height="wrap_content"
+    android:layout_weight="1"
+    android:id="@+id/textView21" />
+  <Button
+    android:text="Button"
+    android:layout_width="0dp"
+    android:layout_weight="1"
+    android:layout_height="wrap_content"
+    android:id="@+id/button2" />
+
+</LinearLayout>
+
+

--- a/Resources/layout/AltDatePickerFragment.axml
+++ b/Resources/layout/AltDatePickerFragment.axml
@@ -7,29 +7,9 @@
   android:id="@+id/pd_root"
   android:minWidth="25px"
   android:minHeight="25px"
-  android:padding="3px" 
-  android:weightSum="3"
- 
+  android:padding="4px" 
+
   >
-  <Button
-    android:text="Button"
-    android:layout_width="0dp"
-    android:layout_weight="1"
-    android:layout_height="wrap_content"
-    android:id="@+id/button1" />
-  <TextView
-    android:text="Medium Text"
-    android:textAppearance="?android:attr/textAppearanceLarge"
-    android:layout_width="0dp"
-    android:layout_height="wrap_content"
-    android:layout_weight="1"
-    android:id="@+id/textView21" />
-  <Button
-    android:text="Button"
-    android:layout_width="0dp"
-    android:layout_weight="1"
-    android:layout_height="wrap_content"
-    android:id="@+id/button2" />
 
 </LinearLayout>
 

--- a/Resources/layout/Main.axml
+++ b/Resources/layout/Main.axml
@@ -5,102 +5,103 @@
     android:layout_height="match_parent"
     android:paddingLeft="5dp"
     android:background="@drawable/Background">
-    <LinearLayout
-        android:orientation="vertical"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:scrollbars="vertical"
-        android:paddingLeft="5dp"
-        android:paddingTop="5dp">
-        <TextView
-            android:id="@+id/Main_Text"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingLeft="5dp"
-            android:textSize="20sp"
-            android:textColor="@color/Text_Color"
-            android:text="@string/Main_DemnaechstZuVerbrauchen"
-            android:tooltipText="@android:string/no"
-            android:visibility="gone" />
-        <TextView
-            android:id="@+id/Main_Text1"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingLeft="5dp"
-            android:textSize="16sp"
-            android:textColor="@color/Text_Error"
-            android:text="@string/Main_ArticlesNearExpiryDate"
-            android:visibility="gone" />
-        <TextView
-            android:id="@+id/Main_Text2"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingLeft="5dp"
-            android:textSize="16sp"
-            android:textColor="@color/Text_Warning"
-            android:text="@string/Main_ArticlesWithExpiryDate"
-            android:visibility="gone" />
-      <TextView
-          android:id="@+id/Main_TextInfo"
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:textColor="#FFFFFF"
-          android:paddingLeft="5dp"
-          android:visibility="gone" />
-      <Button
-            android:id="@+id/MainButton_Kategorie"
-            android:text="@string/Main_Button_BestandNachKategorie"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:textAllCaps="false"
-            android:textSize="18sp"
-            android:drawableLeft="@drawable/ic_storage_white_48dp"
-            android:gravity="left|center_vertical"
-            android:enabled="false"
-            android:drawablePadding="20dp" />
-      <Button
-            android:id="@+id/MainButton_Lagerbestand"
-            android:text="@string/Main_Button_Lagerbestand"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:textAllCaps="false"
-            android:textSize="18sp"
-            android:drawableLeft="@drawable/ic_assignment_white_48dp"
-            android:gravity="left|center_vertical"
-            android:enabled="false"
-            android:drawablePadding="20dp" />
-        <Button
-            android:id="@+id/MainButton_Artikeldaten"
-            android:text="@string/Main_Button_ArtikelListe"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:textAllCaps="false"
-            android:textSize="18sp"
-            android:drawableLeft="@drawable/ic_local_offer_white_48dp"
-            android:gravity="left|center_vertical"
-            android:enabled="false"
-            android:drawablePadding="20dp" />
-        <Button
-            android:id="@+id/MainButton_Barcode"
-            android:text="@string/Main_Button_ArtikelScannen"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:textAllCaps="false"
-            android:textSize="18sp"
-            android:drawableLeft="@drawable/Barcode"
-            android:gravity="left|center_vertical"
-            android:enabled="false"
-            android:drawablePadding="20dp" />
-        <Button
-            android:id="@+id/MainButton_ShoppingList"
-            android:text="@string/Main_Button_Einkaufsliste"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:textAllCaps="false"
-            android:textSize="18sp"
-            android:drawableLeft="@drawable/ic_shopping_cart_white_48dp"
-            android:gravity="left|center_vertical"
-            android:enabled="false"
-            android:drawablePadding="20dp" />
-    </LinearLayout>
+  <LinearLayout
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:scrollbars="vertical"
+    android:paddingLeft="5dp"
+    android:paddingTop="5dp"
+    android:id="@+id/MainLinearLayout">
+    <TextView
+      android:id="@+id/Main_Text"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:paddingLeft="5dp"
+      android:textSize="20sp"
+      android:textColor="@color/Text_Color"
+      android:text="@string/Main_DemnaechstZuVerbrauchen"
+      android:tooltipText="@android:string/no"
+      android:visibility="gone" />
+    <TextView
+      android:id="@+id/Main_Text1"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:paddingLeft="5dp"
+      android:textSize="16sp"
+      android:textColor="@color/Text_Error"
+      android:text="@string/Main_ArticlesNearExpiryDate"
+      android:visibility="gone" />
+    <TextView
+      android:id="@+id/Main_Text2"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:paddingLeft="5dp"
+      android:textSize="16sp"
+      android:textColor="@color/Text_Warning"
+      android:text="@string/Main_ArticlesWithExpiryDate"
+      android:visibility="gone" />
+    <TextView
+      android:id="@+id/Main_TextInfo"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:textColor="#FFFFFF"
+      android:paddingLeft="5dp"
+      android:visibility="gone" />
+    <Button
+      android:id="@+id/MainButton_Kategorie"
+      android:text="@string/Main_Button_BestandNachKategorie"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:textAllCaps="false"
+      android:textSize="18sp"
+      android:drawableLeft="@drawable/ic_storage_white_48dp"
+      android:gravity="left|center_vertical"
+      android:enabled="false"
+      android:drawablePadding="20dp" />
+    <Button
+      android:id="@+id/MainButton_Lagerbestand"
+      android:text="@string/Main_Button_Lagerbestand"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:textAllCaps="false"
+      android:textSize="18sp"
+      android:drawableLeft="@drawable/ic_assignment_white_48dp"
+      android:gravity="left|center_vertical"
+      android:enabled="false"
+      android:drawablePadding="20dp" />
+    <Button
+      android:id="@+id/MainButton_Artikeldaten"
+      android:text="@string/Main_Button_ArtikelListe"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:textAllCaps="false"
+      android:textSize="18sp"
+      android:drawableLeft="@drawable/ic_local_offer_white_48dp"
+      android:gravity="left|center_vertical"
+      android:enabled="false"
+      android:drawablePadding="20dp" />
+    <Button
+      android:id="@+id/MainButton_Barcode"
+      android:text="@string/Main_Button_ArtikelScannen"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:textAllCaps="false"
+      android:textSize="18sp"
+      android:drawableLeft="@drawable/Barcode"
+      android:gravity="left|center_vertical"
+      android:enabled="false"
+      android:drawablePadding="20dp" />
+    <Button
+      android:id="@+id/MainButton_ShoppingList"
+      android:text="@string/Main_Button_Einkaufsliste"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:textAllCaps="false"
+      android:textSize="18sp"
+      android:drawableLeft="@drawable/ic_shopping_cart_white_48dp"
+      android:gravity="left|center_vertical"
+      android:enabled="false"
+      android:drawablePadding="20dp" />
+  </LinearLayout>
 </ScrollView>

--- a/Resources/layout/Settings.axml
+++ b/Resources/layout/Settings.axml
@@ -186,6 +186,14 @@
             android:gravity="left|center_vertical"
             android:textSize="15dp" />
 
+        <Switch
+            android:id="@+id/SettingsButton_AltDatePicker"
+            android:text="Alternativer Datumsauswahl-Dialog"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="left|center_vertical"
+            android:paddingTop="10dp"
+            android:drawablePadding="20dp" />
         <TextView
             android:text="Support" 
             android:layout_width="match_parent"

--- a/Resources/layout/StorageItemQuantityListView.axml
+++ b/Resources/layout/StorageItemQuantityListView.axml
@@ -53,5 +53,6 @@
         android:visibility="visible"
         android:focusable="false"
         android:src="@drawable/baseline_remove_circle_outline_black_36"
+        android:layout_marginLeft="8sp"
         android:background="?android:selectableItemBackground" />
 </RelativeLayout>

--- a/Tools/AltDatePickerFragment.cs
+++ b/Tools/AltDatePickerFragment.cs
@@ -37,8 +37,8 @@ namespace VorratsUebersicht
                 {
                     case "Y":
                         this.rows = 1;
-                        this.columns = 5;
-                        this.amount = 5;
+                        this.columns = 4;
+                        this.amount = 4;
                         this.val_base = base_year;
                         break;
                     case "M":
@@ -85,57 +85,64 @@ namespace VorratsUebersicht
         {
             LinearLayout.LayoutParams lp;
             LinearLayout ll;
+            Button b;
 
             this.DayWasPicked = false;
             this.base_year = base_year;
             this.root.RemoveAllViews();
 
-            BuildGrid("Y");
+            ll = BuildGrid("Y", 5);
+            b = new Button(this.view.Context);
+            b.Text = ">";
+            lp = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MatchParent, LinearLayout.LayoutParams.WrapContent);
+            lp.Width = 0;
+            lp.Weight = 0.5f;
+            lp.SetMargins(1, 1, 1, 1);
+            b.SetBackgroundColor(Android.Graphics.Color.LightGray);
+            b.SetTextColor(Android.Graphics.Color.Black);
+            b.SetPadding(0, 0, 0, 0);
+            b.LayoutParameters = lp;
+            b.Click += OnNextYearCLicked;
+            ll.AddView(b);
+
+            b = new Button(this.view.Context);
+            b.Text = "<";
+            lp = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MatchParent, LinearLayout.LayoutParams.WrapContent);
+            lp.Width = 0;
+            lp.Weight = 0.5f;
+            lp.SetMargins(1, 1, 1, 1);
+            b.SetBackgroundColor(Android.Graphics.Color.LightGray);
+            b.SetTextColor(Android.Graphics.Color.Black);
+            b.SetPadding(0, 0, 0, 0);
+            b.LayoutParameters = lp;
+            b.Click += OnPrevYearCLicked;
+            ll.AddView(b, 0);
+
+
             BuildGrid("M");
             ll = BuildGrid("D");
 
-
-
-            // Kein vernünftiges Layout für die Datumsanzeige gefunden. 
-            // Dieser TextView sollte eigentlich zwischen die Buttons "31" und "OK" mit dem Gewicht von 4 (das LinearLayout hat ein
             this.date_textview = new TextView(this.view.Context);
             lp= new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MatchParent, LinearLayout.LayoutParams.WrapContent);
             lp.Width = 0;
             lp.Weight = 3;
             lp.Gravity = GravityFlags.Center;
-            lp.SetMargins(2, 2, 2, 2);
+            lp.SetMargins(1, 1, 1, 1);
 
             this.date_textview.Gravity = GravityFlags.Center;
-            //this.date_textview.SetTextSize(Android.Util.ComplexUnitType.Dip, 10f);
+            this.date_textview.SetTextSize(Android.Util.ComplexUnitType.Dip, 20f);
             //this.date_textview.SetBackgroundColor(Android.Graphics.Color.Aquamarine);
-            this.date_textview.SetTextAppearance(Android.Resource.Style.TextAppearanceDeviceDefaultLarge);
+            //this.date_textview.SetTextAppearance(Android.Resource.Style.TextAppearanceDeviceDefaultLarge);
             this.date_textview.LayoutParameters = lp;
             ll.AddView(this.date_textview);
 
-            // Space verhällt sich beim Stretch anders als Button
-            for (int i = 0; i < 0; i++)
-            {
-                //Space sp = new Space(this.view.Context);
-                Button sp = new Button(this.view.Context);
-                sp.Text = "SP";
-                lp = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MatchParent, LinearLayout.LayoutParams.WrapContent);
-                lp.Width = 0;
-                lp.Weight = 2;
-                lp.SetMargins(2, 2, 2, 2);
-//                lp.Height = BTN_HEIGHT;
-                sp.SetPadding(0, 0, 0, 0);
-                sp.SetBackgroundColor(Android.Graphics.Color.Transparent);
-                sp.LayoutParameters = lp;
-                ll.AddView(sp);
-            }
-
-            Button b = new Button(this.view.Context);
+            b = new Button(this.view.Context);
             b.Text = "OK";
             lp = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MatchParent, LinearLayout.LayoutParams.WrapContent);
             lp.Width = 0;
             lp.Weight = 1;
-            lp.SetMargins(2, 2, 2, 2);
-//            lp.Height = BTN_HEIGHT;
+            lp.SetMargins(1, 1, 1, 1);
+            //            lp.Height = BTN_HEIGHT;
             b.SetBackgroundColor(Android.Graphics.Color.LightGreen);
             b.SetPadding(0, 0, 0, 0);
             b.LayoutParameters = lp;
@@ -150,7 +157,7 @@ namespace VorratsUebersicht
             ShowDate();
         }
 
-        private LinearLayout BuildGrid(string tag_prefix)
+        private LinearLayout BuildGrid(string tag_prefix, int weight_sum=0)
         {
             DateParams par = new DateParams(tag_prefix, this.base_year);
 
@@ -171,7 +178,7 @@ namespace VorratsUebersicht
                 LinearLayout.LayoutParams lp = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MatchParent, LinearLayout.LayoutParams.WrapContent);
                 llc.Orientation = Orientation.Horizontal;
                 //llc.SetPadding(0, 0, 0, 0);
-                llc.WeightSum = par.columns;
+                llc.WeightSum = weight_sum == 0 ? par.columns : weight_sum;
                 ll.AddView(llc);
                 for (int c = 0; c < par.columns; c++)
                 {
@@ -216,6 +223,7 @@ namespace VorratsUebersicht
                     b.SetBackgroundColor(Android.Graphics.Color.LightGoldenrodYellow);
                 else
                     b.SetBackgroundColor(Android.Graphics.Color.LightGray);// new Android.Graphics.Color(Resource.Color.Text_Warning));
+                b.SetTextColor(Android.Graphics.Color.Black);
                 lp = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MatchParent, LinearLayout.LayoutParams.WrapContent);
                 lp.Weight = 1;
                 lp.Width = 0;
@@ -277,6 +285,14 @@ namespace VorratsUebersicht
         {
             DateSelectedHandler(this.Date);
             this.Dismiss();
+        }
+        private void OnNextYearCLicked(object sender, EventArgs e)
+        {
+            this.InitBase(this.base_year + 1);
+        }
+        private void OnPrevYearCLicked(object sender, EventArgs e)
+        {
+            this.InitBase(this.base_year - 1);
         }
     }
 }

--- a/Tools/AltDatePickerFragment.cs
+++ b/Tools/AltDatePickerFragment.cs
@@ -1,0 +1,282 @@
+﻿using System;
+
+using System.Linq;
+using Android.App;
+using Android.OS;
+using Android.Views;
+using Android.Widget;
+
+namespace VorratsUebersicht
+{
+    public class AltDatePickerFragment : DialogFragment
+    {
+        private const int BTN_HEIGHT = 50;
+        private View view;
+        private LinearLayout root;
+        private bool DayWasPicked;
+
+        private TextView date_textview = null;
+        private int max_days = 31;
+        private int base_year;
+
+        public DateTime? Date = null;
+        public static readonly string TAG = "X:" + typeof(AltDatePickerFragment).Name.ToUpper();
+        Action<DateTime?> DateSelectedHandler = delegate { };
+
+        struct DateParams
+        {
+            public int rows, columns;
+            public string tag_prefix;
+            public int val_base;
+            public int amount;
+
+            public DateParams(string tag_prefix, int base_year)
+            {
+                this.tag_prefix = tag_prefix;
+                switch (tag_prefix)
+                {
+                    case "Y":
+                        this.rows = 1;
+                        this.columns = 5;
+                        this.amount = 5;
+                        this.val_base = base_year;
+                        break;
+                    case "M":
+                        this.rows = 2;
+                        this.columns = 6;
+                        this.amount = 12;
+                        this.val_base = 1;
+                        break;
+                    default:
+                        this.rows = 7;
+                        this.columns = 5;
+                        this.amount = 31;
+                        this.val_base = 1;
+                        break;
+                }
+            }
+        }
+
+        public static AltDatePickerFragment NewInstance(Action<DateTime?> onDateSelected, DateTime? date)
+        {
+            AltDatePickerFragment frag = new AltDatePickerFragment();
+            frag.Date = date;
+            frag.DateSelectedHandler = onDateSelected;
+            return frag;
+        }
+
+        public override View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
+        {
+
+            if (this.Date == null)
+                this.Date = DateTime.Now;
+
+            // Mit oder ohne Titel
+            //Dialog.Window.RequestFeature(WindowFeatures.NoTitle);
+            Dialog.SetTitle("Jahr/Monat/Tag wählen");
+
+            this.view = inflater.Inflate(Resource.Layout.AltDatePickerFragment, container, false);
+            this.root = this.view.FindViewById<LinearLayout>(Resource.Id.pd_root);
+            InitBase(DateTime.Now.Year);
+            return this.view;
+        }
+
+        private void InitBase(int base_year)
+        {
+            LinearLayout.LayoutParams lp;
+            LinearLayout ll;
+
+            this.DayWasPicked = false;
+            this.base_year = base_year;
+            this.root.RemoveAllViews();
+
+            BuildGrid("Y");
+            BuildGrid("M");
+            ll = BuildGrid("D");
+
+
+
+            // Kein vernünftiges Layout für die Datumsanzeige gefunden. 
+            // Dieser TextView sollte eigentlich zwischen die Buttons "31" und "OK" mit dem Gewicht von 4 (das LinearLayout hat ein
+            this.date_textview = new TextView(this.view.Context);
+            lp= new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MatchParent, LinearLayout.LayoutParams.WrapContent);
+            lp.Width = 0;
+            lp.Weight = 3;
+            lp.Gravity = GravityFlags.Center;
+            lp.SetMargins(2, 2, 2, 2);
+
+            this.date_textview.Gravity = GravityFlags.Center;
+            //this.date_textview.SetTextSize(Android.Util.ComplexUnitType.Dip, 10f);
+            //this.date_textview.SetBackgroundColor(Android.Graphics.Color.Aquamarine);
+            this.date_textview.SetTextAppearance(Android.Resource.Style.TextAppearanceDeviceDefaultLarge);
+            this.date_textview.LayoutParameters = lp;
+            ll.AddView(this.date_textview);
+
+            // Space verhällt sich beim Stretch anders als Button
+            for (int i = 0; i < 0; i++)
+            {
+                //Space sp = new Space(this.view.Context);
+                Button sp = new Button(this.view.Context);
+                sp.Text = "SP";
+                lp = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MatchParent, LinearLayout.LayoutParams.WrapContent);
+                lp.Width = 0;
+                lp.Weight = 2;
+                lp.SetMargins(2, 2, 2, 2);
+//                lp.Height = BTN_HEIGHT;
+                sp.SetPadding(0, 0, 0, 0);
+                sp.SetBackgroundColor(Android.Graphics.Color.Transparent);
+                sp.LayoutParameters = lp;
+                ll.AddView(sp);
+            }
+
+            Button b = new Button(this.view.Context);
+            b.Text = "OK";
+            lp = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MatchParent, LinearLayout.LayoutParams.WrapContent);
+            lp.Width = 0;
+            lp.Weight = 1;
+            lp.SetMargins(2, 2, 2, 2);
+//            lp.Height = BTN_HEIGHT;
+            b.SetBackgroundColor(Android.Graphics.Color.LightGreen);
+            b.SetPadding(0, 0, 0, 0);
+            b.LayoutParameters = lp;
+            b.Click += OnCloseCLicked;
+            ll.AddView(b);
+
+            DateTime? d = this.Date;
+            UpdateGrid("Y", d.Value.Year, false);
+            UpdateGrid("M", d.Value.Month, false);
+            UpdateGrid("D", d.Value.Day, false);
+
+            ShowDate();
+        }
+
+        private LinearLayout BuildGrid(string tag_prefix)
+        {
+            DateParams par = new DateParams(tag_prefix, this.base_year);
+
+            LinearLayout ll = this.root;
+            LinearLayout llc = null;
+
+            if (par.rows > 1)
+            {
+                ll = new LinearLayout(this.view.Context);
+                ll.Orientation = Orientation.Vertical;
+                ll.SetPadding(0, 10, 0, 0);
+                this.root.AddView(ll);
+            }
+            int amount = par.amount;
+            for (int r = 0; r < par.rows; r++)
+            {
+                llc = new LinearLayout(this.view.Context);
+                LinearLayout.LayoutParams lp = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MatchParent, LinearLayout.LayoutParams.WrapContent);
+                llc.Orientation = Orientation.Horizontal;
+                //llc.SetPadding(0, 0, 0, 0);
+                llc.WeightSum = par.columns;
+                ll.AddView(llc);
+                for (int c = 0; c < par.columns; c++)
+                {
+                    Button b = new Button(this.view.Context);
+                    b.Text = "" + (r * par.columns + c + par.val_base);
+                    b.Tag = par.tag_prefix + (r * par.columns + c + par.val_base);
+                    b.Click += OnClicked;
+                    llc.AddView(b);
+                    amount -= 1;
+                    if (amount <= 0) break;
+                }
+            }
+            return llc;
+        }
+
+        private void OnClicked(object sender, EventArgs e)
+        {
+            Button b = (Button)sender;
+            string tag = (string)b.Tag;
+            int val = Int32.Parse(tag.Substring(1, tag.Length - 1));
+
+            // Doppelclick
+            if ((tag.Substring(0, 1) == "M" && val == this.Date.Value.Month) || (tag.Substring(0, 1) == "D" && val == this.Date.Value.Day)
+                || (DayWasPicked && tag.Substring(0, 1) == "Y" && val == this.Date.Value.Year))
+            {
+                DateSelectedHandler(this.Date);
+                this.Dismiss();
+                return;
+            }
+            UpdateGrid(tag.Substring(0, 1), val, true);
+        }
+
+        private void UpdateGrid(string tag_prefix, int val, bool user_input)
+        {
+            LinearLayout.LayoutParams lp;
+            DateParams par = new DateParams(tag_prefix, this.base_year);
+
+            for (int i = 0; i < par.amount; i++)
+            {
+                Button b = (Button)this.view.FindViewWithTag(par.tag_prefix + (i + par.val_base));
+                if (par.val_base + i == val)
+                    b.SetBackgroundColor(Android.Graphics.Color.LightGoldenrodYellow);
+                else
+                    b.SetBackgroundColor(Android.Graphics.Color.LightGray);// new Android.Graphics.Color(Resource.Color.Text_Warning));
+                lp = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MatchParent, LinearLayout.LayoutParams.WrapContent);
+                lp.Weight = 1;
+                lp.Width = 0;
+                lp.SetMargins(1, 1, 1, 1);
+//                lp.Height = BTN_HEIGHT;
+                b.SetPadding(0, 0, 0, 0);
+                b.Visibility = (tag_prefix != "D" || i < max_days) ? ViewStates.Visible : ViewStates.Invisible;
+                b.LayoutParameters = lp;
+            }
+
+            int day = this.Date.Value.Day;
+            int month = this.Date.Value.Month;
+            int year = this.Date.Value.Year;
+
+            if (par.tag_prefix == "Y")
+                year = val;
+            else if (par.tag_prefix == "M")
+                month = val;
+            else
+            {
+                if (user_input)
+                    DayWasPicked = true;
+                day = val;
+            }
+
+            if (par.tag_prefix != "D")
+            {
+                this.max_days = 30;
+                int[] ldays = { 1, 3, 5, 7, 8, 10, 12 };
+                if (ldays.Contains(month))
+                    this.max_days = 31;
+                if (month == 2)
+                {
+                    // Schaltjahrberechnung funktioniert so bis 2399
+                    if ((year % 4 == 0) && (year % 100 != 0))
+                        this.max_days = 29;
+                    else
+                        this.max_days = 28;
+                }
+                if (!DayWasPicked)
+                    day = this.max_days;
+            }
+            if (day > this.max_days)
+                day = this.max_days;
+            this.Date = new DateTime(year, month, day);
+
+            if (par.tag_prefix != "D")
+                UpdateGrid("D", day, false);
+
+            ShowDate();
+        }
+
+        private void ShowDate()
+        {
+            if (this.date_textview != null)
+                this.date_textview.Text = this.Date.Value.ToShortDateString();
+        }
+        private void OnCloseCLicked(object sender, EventArgs e)
+        {
+            DateSelectedHandler(this.Date);
+            this.Dismiss();
+        }
+    }
+}

--- a/Tools/AltDatePickerFragment.cs
+++ b/Tools/AltDatePickerFragment.cs
@@ -10,10 +10,10 @@ namespace VorratsUebersicht
 {
     public class AltDatePickerFragment : DialogFragment
     {
-        private const int BTN_HEIGHT = 50;
         private View view;
         private LinearLayout root;
         private bool DayWasPicked;
+        private string last_clicked_tag = "";
 
         private TextView date_textview = null;
         private int max_days = 31;
@@ -72,8 +72,8 @@ namespace VorratsUebersicht
                 this.Date = DateTime.Now;
 
             // Mit oder ohne Titel
-            //Dialog.Window.RequestFeature(WindowFeatures.NoTitle);
-            Dialog.SetTitle("Jahr/Monat/Tag wählen");
+            Dialog.Window.RequestFeature(WindowFeatures.NoTitle);
+            //Dialog.SetTitle("Jahr/Monat/Tag wählen");
 
             this.view = inflater.Inflate(Resource.Layout.AltDatePickerFragment, container, false);
             this.root = this.view.FindViewById<LinearLayout>(Resource.Id.pd_root);
@@ -91,12 +91,45 @@ namespace VorratsUebersicht
             this.base_year = base_year;
             this.root.RemoveAllViews();
 
-            ll = BuildGrid("Y", 5);
+            /*
+                        // Überschrift und 'Kein Datum' in die oberste Zeile
+                        ll = new LinearLayout(this.view.Context);
+                        lp = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MatchParent, LinearLayout.LayoutParams.WrapContent);
+                        ll.Orientation = Orientation.Horizontal;
+                        ll.WeightSum = 10;
+                        this.root.AddView(ll);
+                        TextView tv = new TextView(this.view.Context);
+                        tv.Text = "Jahr / Monat / Tag wählen";
+                        lp = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MatchParent, LinearLayout.LayoutParams.WrapContent);
+                        lp.Width = 0;
+                        lp.Weight = 7;
+                        lp.Gravity = GravityFlags.Center;
+                        lp.SetMargins(1, 1, 1, 1);
+                        tv.Gravity = GravityFlags.Center;
+                        tv.SetTextSize(Android.Util.ComplexUnitType.Dip, 20f);
+                        tv.LayoutParameters = lp;
+                        ll.AddView(tv);
+
+                        b = new Button(this.view.Context);
+                        b.Text = "Kein Datum";
+                        lp = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MatchParent, LinearLayout.LayoutParams.WrapContent);
+                        lp.Width = 0;
+                        lp.Weight = 3;
+                        lp.SetMargins(1, 1, 1, 1);
+                        b.SetBackgroundColor(Android.Graphics.Color.OrangeRed);
+                        b.SetTextColor(Android.Graphics.Color.Black);
+                        b.SetPadding(0, 0, 0, 0);
+                        b.LayoutParameters = lp;
+                        b.Click += delegate { DateSelectedHandler(null); Dismiss(); };
+                        ll.AddView(b);
+            */
+
+            ll = BuildGrid("Y", 10);
             b = new Button(this.view.Context);
             b.Text = ">";
             lp = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MatchParent, LinearLayout.LayoutParams.WrapContent);
             lp.Width = 0;
-            lp.Weight = 0.5f;
+            lp.Weight = 1;
             lp.SetMargins(1, 1, 1, 1);
             b.SetBackgroundColor(Android.Graphics.Color.LightGray);
             b.SetTextColor(Android.Graphics.Color.Black);
@@ -109,7 +142,7 @@ namespace VorratsUebersicht
             b.Text = "<";
             lp = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MatchParent, LinearLayout.LayoutParams.WrapContent);
             lp.Width = 0;
-            lp.Weight = 0.5f;
+            lp.Weight = 1;
             lp.SetMargins(1, 1, 1, 1);
             b.SetBackgroundColor(Android.Graphics.Color.LightGray);
             b.SetTextColor(Android.Graphics.Color.Black);
@@ -125,24 +158,36 @@ namespace VorratsUebersicht
             this.date_textview = new TextView(this.view.Context);
             lp= new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MatchParent, LinearLayout.LayoutParams.WrapContent);
             lp.Width = 0;
-            lp.Weight = 3;
+            lp.Weight = 2;
             lp.Gravity = GravityFlags.Center;
             lp.SetMargins(1, 1, 1, 1);
 
             this.date_textview.Gravity = GravityFlags.Center;
-            this.date_textview.SetTextSize(Android.Util.ComplexUnitType.Dip, 20f);
+            //this.date_textview.SetTextSize(Android.Util.ComplexUnitType.Dip, 20f);
             //this.date_textview.SetBackgroundColor(Android.Graphics.Color.Aquamarine);
             //this.date_textview.SetTextAppearance(Android.Resource.Style.TextAppearanceDeviceDefaultLarge);
             this.date_textview.LayoutParameters = lp;
             ll.AddView(this.date_textview);
 
             b = new Button(this.view.Context);
+            b.Text = "Kein Datum";
+            lp = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MatchParent, LinearLayout.LayoutParams.WrapContent);
+            lp.Width = 0;
+            lp.Weight = 3;
+            lp.SetMargins(1, 1, 1, 1);
+            b.SetBackgroundColor(Android.Graphics.Color.OrangeRed);
+            b.SetTextColor(Android.Graphics.Color.Black);
+            b.SetPadding(0, 0, 0, 0);
+            b.LayoutParameters = lp;
+            b.Click += delegate { DateSelectedHandler(null); Dismiss(); };
+            ll.AddView(b);
+
+            b = new Button(this.view.Context);
             b.Text = "OK";
             lp = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MatchParent, LinearLayout.LayoutParams.WrapContent);
             lp.Width = 0;
-            lp.Weight = 1;
+            lp.Weight = 3;
             lp.SetMargins(1, 1, 1, 1);
-            //            lp.Height = BTN_HEIGHT;
             b.SetBackgroundColor(Android.Graphics.Color.LightGreen);
             b.SetPadding(0, 0, 0, 0);
             b.LayoutParameters = lp;
@@ -157,7 +202,7 @@ namespace VorratsUebersicht
             ShowDate();
         }
 
-        private LinearLayout BuildGrid(string tag_prefix, int weight_sum=0)
+        private LinearLayout BuildGrid(string tag_prefix, int weight_sum=0, int button_weight=1)
         {
             DateParams par = new DateParams(tag_prefix, this.base_year);
 
@@ -178,7 +223,7 @@ namespace VorratsUebersicht
                 LinearLayout.LayoutParams lp = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MatchParent, LinearLayout.LayoutParams.WrapContent);
                 llc.Orientation = Orientation.Horizontal;
                 //llc.SetPadding(0, 0, 0, 0);
-                llc.WeightSum = weight_sum == 0 ? par.columns : weight_sum;
+                llc.WeightSum = weight_sum == 0 ? par.columns*2 : weight_sum;
                 ll.AddView(llc);
                 for (int c = 0; c < par.columns; c++)
                 {
@@ -200,6 +245,15 @@ namespace VorratsUebersicht
             string tag = (string)b.Tag;
             int val = Int32.Parse(tag.Substring(1, tag.Length - 1));
 
+            if (tag == this.last_clicked_tag)
+            {
+                DateSelectedHandler(this.Date);
+                this.Dismiss();
+                return;
+            }
+            this.last_clicked_tag = tag;
+
+            /*
             // Doppelclick
             if ((tag.Substring(0, 1) == "M" && val == this.Date.Value.Month) || (tag.Substring(0, 1) == "D" && val == this.Date.Value.Day)
                 || (DayWasPicked && tag.Substring(0, 1) == "Y" && val == this.Date.Value.Year))
@@ -208,6 +262,7 @@ namespace VorratsUebersicht
                 this.Dismiss();
                 return;
             }
+            */
             UpdateGrid(tag.Substring(0, 1), val, true);
         }
 
@@ -225,10 +280,9 @@ namespace VorratsUebersicht
                     b.SetBackgroundColor(Android.Graphics.Color.LightGray);// new Android.Graphics.Color(Resource.Color.Text_Warning));
                 b.SetTextColor(Android.Graphics.Color.Black);
                 lp = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MatchParent, LinearLayout.LayoutParams.WrapContent);
-                lp.Weight = 1;
+                lp.Weight = 2;
                 lp.Width = 0;
                 lp.SetMargins(1, 1, 1, 1);
-//                lp.Height = BTN_HEIGHT;
                 b.SetPadding(0, 0, 0, 0);
                 b.Visibility = (tag_prefix != "D" || i < max_days) ? ViewStates.Visible : ViewStates.Invisible;
                 b.LayoutParameters = lp;
@@ -279,7 +333,11 @@ namespace VorratsUebersicht
         private void ShowDate()
         {
             if (this.date_textview != null)
-                this.date_textview.Text = this.Date.Value.ToShortDateString();
+            {
+                string s = this.Date.Value.ToShortDateString();
+                s = s.Insert(s.Length-4,"\n");
+                this.date_textview.Text = s;
+            }
         }
         private void OnCloseCLicked(object sender, EventArgs e)
         {

--- a/Vorratsübersicht.csproj
+++ b/Vorratsübersicht.csproj
@@ -36,7 +36,7 @@
     <EnableLLVM>false</EnableLLVM>
     <BundleAssemblies>false</BundleAssemblies>
     <EmbedAssembliesIntoApk>false</EmbedAssembliesIntoApk>
-    <IntermediateOutputPath>C:\Users\CHRIST~1\AppData\Local\Temp\vs1574.tmp\Debug\</IntermediateOutputPath>
+    <IntermediateOutputPath>C:\Users\Wolf\AppData\Local\Temp\vs8B0E.tmp\Debug\</IntermediateOutputPath>
     <AndroidSupportedAbis />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -58,7 +58,7 @@
     <Debugger>Xamarin</Debugger>
     <AndroidEnableMultiDex>False</AndroidEnableMultiDex>
     <EnableProguard>False</EnableProguard>
-    <IntermediateOutputPath>C:\Users\CHRIST~1\AppData\Local\Temp\vs1574.tmp\Release\</IntermediateOutputPath>
+    <IntermediateOutputPath>C:\Users\Wolf\AppData\Local\Temp\vs8B0E.tmp\Release\</IntermediateOutputPath>
     <AndroidSupportedAbis>armeabi-v7a;arm64-v8a</AndroidSupportedAbis>
   </PropertyGroup>
   <ItemGroup>
@@ -162,6 +162,7 @@
     <None Include="Service\PeriodicBackgroundService.cs" />
     <Compile Include="Tools\BitmapHelpers.cs" />
     <Compile Include="Tools\CsvExport.cs" />
+    <Compile Include="Tools\AltDatePickerFragment.cs" />
     <Compile Include="Tools\Logging.cs" />
     <Compile Include="Tools\QuantityAndUnit.cs" />
     <Compile Include="Tools\Settings.cs" />
@@ -727,6 +728,9 @@
   </ItemGroup>
   <ItemGroup>
     <AndroidResource Include="Resources\xml\provider_paths.xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <AndroidResource Include="Resources\layout\AltDatePickerFragment.axml" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
   <Import Project="packages\Xamarin.Android.Support.Compat.25.4.0.1\build\MonoAndroid70\Xamarin.Android.Support.Compat.targets" Condition="Exists('packages\Xamarin.Android.Support.Compat.25.4.0.1\build\MonoAndroid70\Xamarin.Android.Support.Compat.targets')" />


### PR DESCRIPTION
Die Auswahl zwischen den beiden DialogFragments ist unschön, aber mir fällt da gerade keine Bessere Methode ein, als die Aufrufe jeweils aufzudoppeln.

In den Einstellungen kann zwischen dem normalen (default) und dem alternativen Dialog gewechselt werden.

Das MHD wird entweder mit einem vollständigen Datum oder nur mit Jahr/Monat angegeben. Wird dabei der Tag nicht angegeben, so gilt das MHD bis zum letzten Tag des entsprechenden Monats.

**Bedienung des neuen Dialogs:**

Ein Klick auf ein Jahr oder Monat setzt den Tag auf den jeweils letzten Tag des gewählten Monats. Ein weiterer Klick auf den Monat übernimmt das Datum.
Wenn man danach stattdessen einen Tag auswählt, wird auch dieser bei erneutem Klick übernommen. Der OK-Knopf ist also nicht unbedingt notwendig.

Sobald man einen Tag auswählt, wird der Tag nicht mehr durch Klicken auf Jahr oder Monat  verändert und man kann mit Erneutem Klick auf das gewählte Jahr das Datum übernehmen.

**Die Möglichkeiten, ein Datum zu übernehmen, zusammengefasst:**
* Klick auf Jahr, Doppelklick auf Monat => Letzter Tag des gewählten Jahr/Monats wird übernommen
* Klick auf Jahr, Klick auf Monat, Doppelklick auf Tag
* Klick auf Tag, Doppelklick auf Monat
* Klick auf Tag, Klick auf Monat, Doppelklick auf Jahr
