### PR TITLE
Backup-Pfad anpassbar gemacht.

### DIFF
--- a/Activities/SettingsActivity.cs
+++ b/Activities/SettingsActivity.cs
@@ -91,6 +91,13 @@ namespace VorratsUebersicht
             Button buttonRestore = FindViewById<Button>(Resource.Id.SettingsButton_Restore);
             buttonRestore.Click += ButtonRestore_Click;
 
+            EditText backupPath = FindViewById<EditText>(Resource.Id.SettingsButton_BackupPath);
+            backupPath.Text = Settings.GetString("BackupPath", Android.OS.Environment.GetExternalStoragePublicDirectory(Android.OS.Environment.DirectoryDownloads).AbsolutePath);
+            backupPath.TextChanged += delegate {
+                EditText _backupPath = FindViewById<EditText>(Resource.Id.SettingsButton_BackupPath);
+                Settings.PutString("BackupPath", _backupPath.Text);
+            };
+
             Button buttonCsvExportArticles = FindViewById<Button>(Resource.Id.SettingsButton_CsvExportArticles);
             buttonCsvExportArticles.Click += ButtonCsvExportArticles_Click;
 
@@ -512,8 +519,8 @@ namespace VorratsUebersicht
         private void ButtonRestore_Click(object sender, EventArgs e)
         {
             // Backups müssen sich im Download Verzeichnis befinden.
-            var downloadFolder = Android.OS.Environment.GetExternalStoragePublicDirectory(
-                                    Android.OS.Environment.DirectoryDownloads).AbsolutePath;
+            var downloadFolder = Settings.GetString("BackupPath", Android.OS.Environment.GetExternalStoragePublicDirectory(
+                Android.OS.Environment.DirectoryDownloads).AbsolutePath);
 
             var selectFile = new Intent(this, typeof(SelectFileActivity));
             selectFile.PutExtra("Text",         "Backup auswählen:");
@@ -538,8 +545,8 @@ namespace VorratsUebersicht
 
             var databaseFilePath = Android_Database.Instance.GetProductiveDatabasePath();
 
-            var downloadFolder = Android.OS.Environment.GetExternalStoragePublicDirectory(
-                                    Android.OS.Environment.DirectoryDownloads).AbsolutePath;
+            var downloadFolder = Settings.GetString("BackupPath", Android.OS.Environment.GetExternalStoragePublicDirectory(
+                Android.OS.Environment.DirectoryDownloads).AbsolutePath);
 
             string backupFileName;
             string databaseFileName = Path.GetFileNameWithoutExtension(databaseFilePath);

--- a/Resources/layout/Settings.axml
+++ b/Resources/layout/Settings.axml
@@ -90,6 +90,19 @@
             android:textAllCaps="false"
             android:gravity="left|center_vertical"
             android:drawablePadding="10dp" />
+        <TextView
+            android:text="Backup-Pfad:"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingTop="10dp" />
+        <EditText
+            android:id="@+id/SettingsButton_BackupPath"
+            android:text=""
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textAllCaps="false"
+            android:gravity="left|center_vertical"
+            android:textSize="15dp" />
 
         <TextView
             android:text="Zum Kennenlernen oder Testen neuer Funktionalität"


### PR DESCRIPTION
So kann man Backups in einem speziellen, gesyncten Ordner ablegen, da der Sync des Standard-Download-Verzeichnisses selten sinnvoll ist.